### PR TITLE
fix EventHubsDirectDStream not serializable error

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubs/client/EventHubsClient.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/client/EventHubsClient.scala
@@ -271,7 +271,7 @@ private[spark] class EventHubsClient(private val ehConf: EventHubsConf)
 
     result.asScala.toMap.mapValues { seqNo =>
       { if (seqNo == -1L) 0L else seqNo }
-    }
+    }.map(identity)
   }
 }
 


### PR DESCRIPTION
I run a Spark application with following error:
```
18/03/15 05:26:59 INFO ApplicationMaster: Unregistering ApplicationMaster with FAILED (diag message: User class threw exception: java.io.NotSerializableException: DStream checkpointing has been enabled but the DStreams with their functions are not serializable
scala.collection.immutable.MapLike$$anon$2
Serialization stack:
	- object not serializable (class: scala.collection.immutable.MapLike$$anon$2, value: Map(0 -> 584345428, 5 -> 533513265, 10 -> 35, 24 -> 33, 25 -> 33, 14 -> 34, 20 -> 33, 29 -> 8654525, 1 -> 33, 6 -> 35, 28 -> 32, 21 -> 33, 9 -> 35, 13 -> 35, 2 -> 33, 17 -> 34, 22 -> 647296886, 27 -> 32, 12 -> 408227438, 7 -> 35, 3 -> 2540032, 18 -> 34, 16 -> 550993529, 31 -> 33, 11 -> 737052177, 26 -> 771600016, 23 -> 33, 8 -> 35, 30 -> 33, 19 -> 31494201, 4 -> 572914252, 15 -> 34))
	- field (class: org.apache.spark.streaming.eventhubs.EventHubsDirectDStream, name: org$apache$spark$streaming$eventhubs$EventHubsDirectDStream$$fromSeqNos, type: interface scala.collection.immutable.Map)
	- object (class org.apache.spark.streaming.eventhubs.EventHubsDirectDStream, org.apache.spark.streaming.eventhubs.EventHubsDirectDStream@24153826)
	- element of array (index: 0)
	- array (class [Ljava.lang.Object;, size 16)
	- field (class: scala.collection.mutable.ArrayBuffer, name: array, type: class [Ljava.lang.Object;)
	- object (class scala.collection.mutable.ArrayBuffer, ArrayBuffer(org.apache.spark.streaming.eventhubs.EventHubsDirectDStream@24153826))
	- writeObject data (class: org.apache.spark.streaming.DStreamGraph)
	- object (class org.apache.spark.streaming.DStreamGraph, org.apache.spark.streaming.DStreamGraph@5c533b41)
	- field (class: org.apache.spark.streaming.Checkpoint, name: graph, type: class org.apache.spark.streaming.DStreamGraph)
	- object (class org.apache.spark.streaming.Checkpoint, org.apache.spark.streaming.Checkpoint@512bf044))
18/03/15 05:26:59 INFO AMRMClientImpl: Waiting for application to be successfully unregistered.
18/03/15 05:26:59 INFO ApplicationMaster: Deleting staging directory wasb://lam-agg-apc-2018-03-06t02-37-42-319z@agglamapc.blob.core.windows.net/user/livy/.sparkStaging/application_1520578341204_0009
```

It's a scala bug: https://stackoverflow.com/questions/32900862/map-can-not-be-serializable-in-scala