### PR TITLE
Updating to 2.3.1

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -39,14 +39,14 @@ Then add the following dependency declaration:
     <dependency>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-eventhubs-spark_[2.XX]</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </dependency>
 ```
 
 ### SBT Dependency
 
     // https://mvnrepository.com/artifact/com.microsoft.azure/azure-eventhubs-spark_2.11
-    libraryDependencies += "com.microsoft.azure" %% "azure-eventhubs-spark" %% "2.3.0"
+    libraryDependencies += "com.microsoft.azure" %% "azure-eventhubs-spark" %% "2.3.1"
  
 ## Filing Issues
 

--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ By making Event Hubs and Spark easier to use together, we hope this connector ma
 #### Spark
 |Spark Version|Package Name|Package Version|
 |-------------|------------|----------------|
-|Spark 2.3|azure-eventhubs-spark_2.11|[![Maven Central](https://img.shields.io/badge/maven%20central-2.3.0-brightgreen.svg)](https://search.maven.org/#artifactdetails%7Ccom.microsoft.azure%7Cazure-eventhubs-spark_2.11%7C2.3.0%7Cjar)|
+|Spark 2.3|azure-eventhubs-spark_2.11|[![Maven Central](https://img.shields.io/badge/maven%20central-2.3.1-brightgreen.svg)](https://search.maven.org/#artifactdetails%7Ccom.microsoft.azure%7Cazure-eventhubs-spark_2.11%7C2.3.1%7Cjar)|
 |Spark 2.2|azure-eventhubs-spark_2.11|[![Maven Central](https://img.shields.io/maven-central/v/com.microsoft.azure/azure-eventhubs-spark_2.11/2.2.0-PREVIEW.svg)](https://search.maven.org/#artifactdetails%7Ccom.microsoft.azure%7Cazure-eventhubs-spark_2.11%7C2.2.0-PREVIEW%7Cjar)|
 |Spark 2.1|azure-eventhubs-spark_2.11|[![Maven Central](https://img.shields.io/maven-central/v/com.microsoft.azure/azure-eventhubs-spark_2.11/2.2.0-PREVIEW.svg)](https://search.maven.org/#artifactdetails%7Ccom.microsoft.azure%7Cazure-eventhubs-spark_2.11%7C2.2.0-PREVIEW%7Cjar)|
 
 #### Databricks
 |Databricks Runtime Version|Artifact Id|Package Version|
 |-------------|------------|----------------|
-|Databricks Runtime 4.X|azure-eventhubs-spark_2.11|[![Maven Central](https://img.shields.io/badge/maven%20central-2.3.0-brightgreen.svg)](https://search.maven.org/#artifactdetails%7Ccom.microsoft.azure%7Cazure-eventhubs-spark_2.11%7C2.3.0%7Cjar)|
-|Databricks Runtime 3.5|azure-eventhubs-spark_2.11|[![Maven Central](https://img.shields.io/badge/maven%20central-2.3.0-brightgreen.svg)](https://search.maven.org/#artifactdetails%7Ccom.microsoft.azure%7Cazure-eventhubs-spark_2.11%7C2.3.0%7Cjar)|
+|Databricks Runtime 4.X|azure-eventhubs-spark_2.11|[![Maven Central](https://img.shields.io/badge/maven%20central-2.3.1-brightgreen.svg)](https://search.maven.org/#artifactdetails%7Ccom.microsoft.azure%7Cazure-eventhubs-spark_2.11%7C2.3.1%7Cjar)|
+|Databricks Runtime 3.5|azure-eventhubs-spark_2.11|[![Maven Central](https://img.shields.io/badge/maven%20central-2.3.1-brightgreen.svg)](https://search.maven.org/#artifactdetails%7Ccom.microsoft.azure%7Cazure-eventhubs-spark_2.11%7C2.3.1%7Cjar)|
 
 #### Roadmap
 
@@ -47,7 +47,7 @@ For Scala/Java applications using SBT/Maven project definitions, link your appli
 
     groupId = com.microsoft.azure
     artifactId = azure-eventhubs-spark_2.11
-    version = 2.3.0
+    version = 2.3.1
 
 ### Documentation
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-eventhubs-spark-parent_2.11</artifactId>
-    <version>2.3.0</version>
+    <version>2.3.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>azure-eventhubs-spark_2.11</artifactId>

--- a/docs/PySpark/structured-streaming-pyspark-jupyter.md
+++ b/docs/PySpark/structured-streaming-pyspark-jupyter.md
@@ -8,7 +8,7 @@ Jupyter Kernel Used: **PySpark3**
 
 ```pyspark3
 %%configure -f
-{"conf": {"spark.jars.packages": "com.microsoft.azure:azure-eventhubs-spark_2.11:2.3.0"}}
+{"conf": {"spark.jars.packages": "com.microsoft.azure:azure-eventhubs-spark_2.11:2.3.1"}}
 ```
 
 2. Defining variables needed to connect to Azure Event Hubs.

--- a/docs/spark-streaming-eventhubs-integration.md
+++ b/docs/spark-streaming-eventhubs-integration.md
@@ -21,7 +21,7 @@ For Scala/Java applications using SBT/Maven project defnitions, link your applic
 ```
   groupId = com.microsoft.azure
   artifactId = azure-eventhubs-spark_2.11
-  version = 2.3.0
+  version = 2.3.1
 ```
 
 For Python applications, you need to add this above library and its dependencies when deploying your application.

--- a/docs/structured-streaming-eventhubs-integration.md
+++ b/docs/structured-streaming-eventhubs-integration.md
@@ -21,7 +21,7 @@ For Scala/Java applications using SBT/Maven project defnitions, link your applic
 ```
   groupId = com.microsoft.azure
   artifactId = azure-eventhubs-spark_2.11
-  version = 2.3.0
+  version = 2.3.1
 ```
 
 For Python applications, you need to add this above library and its dependencies when deploying your application.
@@ -327,11 +327,11 @@ df.selectExpr("partitionKey", "body")
 As with any Spark applications, `spark-submit` is used to launch your application. `azure-eventhubs-spark_2.11`
 and its dependencies can be directly added to `spark-submit` using `--packages`, such as,
 
-    ./bin/spark-submit --packages com.microsoft.azure:azure-eventhubs-spark_2.11:2.3.0 ...
+    ./bin/spark-submit --packages com.microsoft.azure:azure-eventhubs-spark_2.11:2.3.1 ...
 
 For experimenting on `spark-shell`, you can also use `--packages` to add `azure-eventhubs-spark_2.11` and its dependencies directly,
 
-    ./bin/spark-shell --packages com.microsoft.azure:azure-eventhubs-spark_2.11:2.3.0 ...
+    ./bin/spark-shell --packages com.microsoft.azure:azure-eventhubs-spark_2.11:2.3.1 ...
 
 See [Application Submission Guide](https://spark.apache.org/docs/latest/submitting-applications.html) for more details about submitting
 applications with external dependencies.

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>com.microsoft.azure</groupId>
   <artifactId>azure-eventhubs-spark-parent_2.11</artifactId>
-  <version>2.3.0</version>
+  <version>2.3.1</version>
   <packaging>pom</packaging>
 
   <name>EventHubs+Spark Parent POM</name>


### PR DESCRIPTION
Release notes:
- Translate method optimization for quicker startup  
- Default starting position is EndOfStream 
- Added Receiver Identifier for improved tracing 
- Moved to latest Event Hubs Java Client
- Various bug fixes