### PR TITLE
[WIP]fix get wrong connection when trnaslation & using multiple eventhubs

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,7 +28,6 @@
   </parent>
   <artifactId>azure-eventhubs-spark_2.11</artifactId>
   <packaging>jar</packaging>
-
   <dependencies>
     <dependency>
         <groupId>org.apache.spark</groupId>

--- a/core/src/main/scala/org/apache/spark/eventhubs/client/EventHubsClient.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/client/EventHubsClient.scala
@@ -186,7 +186,7 @@ private[spark] class EventHubsClient(private val ehConf: EventHubsConf)
       partitionSender = null
     }
     if (_client != null) {
-      ClientConnectionPool.returnClient(_client)
+      ClientConnectionPool.returnClient(ehConf, _client)
       _client = null
     }
   }


### PR DESCRIPTION
When using multiple EventHubs with the same name, it will use wrong connection.
Related to issue: https://github.com/Azure/azure-event-hubs-spark/issues/315