### PR TITLE
Retry getRuntimeInfo call

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubs/package.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/package.scala
@@ -40,6 +40,7 @@ package object eventhubs {
   val DefaultUseSimulatedClient = "false"
   val StartingSequenceNumber = 0L
   val DefaultEpoch = 0L
+  val RetryCount = 3
 
   type PartitionId = Int
   val PartitionId = Int


### PR DESCRIPTION
close #319 

On failure, the Spark connector will retry `getRunTimeInfo` calls. 