### PR TITLE
Fix data loss checking in getBatch

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsSource.scala
@@ -230,12 +230,12 @@ private[spark] class EventHubsSource private[eventhubs] (sqlContext: SQLContext,
     }
     fromSeqNos.map {
       case (nAndP, seqNo) =>
-        if (seqNo < currentSeqNos.get(nAndP)) {
+        if (seqNo < earliestSeqNos.get(nAndP)) {
           reportDataLoss(
             s"Starting seqNo $seqNo in partition ${nAndP.partitionId} of EventHub ${nAndP.ehName} " +
               s"is behind the earliest sequence number ${currentSeqNos.get(nAndP)} " +
               s"present in the service. Some events may have expired and been missed.")
-          nAndP -> currentSeqNos.get(nAndP)
+          nAndP -> earliestSeqNos.get(nAndP)
         } else {
           nAndP -> seqNo
         }


### PR DESCRIPTION
Data loss warning should only print if we are behind the `earliestSeqNo` in the partition. Before this fix, we were checking with a later sequence number which caused this logging to print very often. 

close #321 