### PR TITLE
add properties to schema

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubs/utils/EventHubsTestUtils.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/utils/EventHubsTestUtils.scala
@@ -27,7 +27,7 @@ import com.microsoft.azure.eventhubs.impl.AmqpConstants.{
 }
 import com.microsoft.azure.eventhubs.impl.EventDataImpl
 import org.apache.qpid.proton.amqp.Binary
-import org.apache.qpid.proton.amqp.messaging.{ Data, MessageAnnotations }
+import org.apache.qpid.proton.amqp.messaging.{ ApplicationProperties, Data, MessageAnnotations }
 import org.apache.qpid.proton.message.Message
 import org.apache.qpid.proton.message.Message.Factory
 import org.apache.spark.eventhubs.{ EventHubsConf, NameAndPartition }
@@ -47,8 +47,11 @@ private[spark] class EventHubsTestUtils {
 
   import EventHubsTestUtils._
 
-  def send(ehName: String, partitionId: Option[PartitionId] = None, data: Seq[Int]): Seq[Int] = {
-    eventHubs(ehName).send(partitionId, data)
+  def send(ehName: String,
+           partitionId: Option[PartitionId] = None,
+           data: Seq[Int],
+           properties: Option[Map[String, Object]] = None): Seq[Int] = {
+    eventHubs(ehName).send(partitionId, data, properties)
   }
 
   def getLatestSeqNos(ehConf: EventHubsConf): Map[NameAndPartition, SequenceNumber] = {
@@ -98,10 +101,12 @@ private[spark] class EventHubsTestUtils {
   }
 
   // Put 'count' events in every simulated EventHubs partition
-  def populateUniformly(ehName: String, count: Int): Unit = {
+  def populateUniformly(ehName: String,
+                        count: Int,
+                        properties: Option[Map[String, Object]] = None): Unit = {
     val eventHub = eventHubs(ehName)
     for (i <- 0 until eventHub.partitionCount) {
-      eventHub.send(Some(i), 0 until count)
+      eventHub.send(Some(i), 0 until count, properties)
     }
   }
 }
@@ -113,7 +118,9 @@ private[spark] object EventHubsTestUtils {
 
   private[utils] val eventHubs: mutable.Map[String, SimulatedEventHubs] = mutable.Map.empty
 
-  def createEventData(event: Array[Byte], seqNo: Long): EventData = {
+  def createEventData(event: Array[Byte],
+                      seqNo: Long,
+                      properties: Option[Map[String, Object]]): EventData = {
     val constructor = classOf[EventDataImpl].getDeclaredConstructor(classOf[Message])
     constructor.setAccessible(true)
 
@@ -129,6 +136,10 @@ private[spark] object EventHubsTestUtils {
 
     val body = new Data(new Binary(event))
     val msg = Factory.create(null, null, msgAnnotations, null, null, body, null)
+    if (properties.isDefined) {
+      val appProperties = new ApplicationProperties(properties.get.asJava)
+      msg.setApplicationProperties(appProperties)
+    }
     constructor.newInstance(msg).asInstanceOf[EventData]
   }
 }
@@ -161,15 +172,17 @@ private[spark] class SimulatedEventHubs(val name: String, val partitionCount: In
     (for { _ <- 0 until eventCount } yield partitions(partitionId).get(seqNo)).asJava
   }
 
-  private[utils] def send(partitionId: Option[PartitionId], events: Seq[Int]): Seq[Int] = {
+  private[utils] def send(partitionId: Option[PartitionId],
+                          events: Seq[Int],
+                          properties: Option[Map[String, Object]]): Seq[Int] = {
     if (partitionId.isDefined) {
-      partitions(partitionId.get).send(events)
+      partitions(partitionId.get).send(events, properties)
     } else {
       for (event <- events) {
         synchronized {
           val part = count % this.partitionCount
           count += 1
-          this.send(Some(part), Seq(event))
+          this.send(Some(part), Seq(event), properties)
         }
       }
     }
@@ -217,7 +230,6 @@ private[spark] class SimulatedEventHubs(val name: String, val partitionCount: In
 
   /** Specifies the contents of each partition. */
   private[utils] class SimulatedEventHubsPartition {
-    import com.microsoft.azure.eventhubs.impl.AmqpConstants._
 
     private var data: Seq[EventData] = Seq.empty
 
@@ -227,37 +239,23 @@ private[spark] class SimulatedEventHubs(val name: String, val partitionCount: In
     private val constructor = classOf[EventDataImpl].getDeclaredConstructor(classOf[Message])
     constructor.setAccessible(true)
 
-    private[utils] def send(events: Seq[Int]): Unit = {
+    private[utils] def send(events: Seq[Int], properties: Option[Map[String, Object]]): Unit = {
       synchronized {
         for (event <- events) {
-          val seqNo = data.size.toLong.asInstanceOf[AnyRef]
-
-          // This value is not accurate. However, "offet" is never used in testing.
-          // Placing dummy value here because one is required in order for EventData
-          // to serialize/de-serialize properly during tests.
-          val offset = data.size.toString.asInstanceOf[AnyRef]
-
-          val time = new Date(System.currentTimeMillis()).asInstanceOf[AnyRef]
-
-          val msgAnnotations = new MessageAnnotations(
-            Map(SEQUENCE_NUMBER -> seqNo, OFFSET -> offset, ENQUEUED_TIME_UTC -> time).asJava)
-
-          val body = new Data(new Binary(s"$event".getBytes("UTF-8")))
-
-          val msg = Factory.create(null, null, msgAnnotations, null, null, body, null)
-
-          data = data :+ constructor.newInstance(msg).asInstanceOf[EventData]
+          val seqNo = data.size.toLong
+          val e = EventHubsTestUtils.createEventData(s"$event".getBytes("UTF-8"), seqNo, properties)
+          data = data :+ e
         }
       }
     }
 
     private[utils] def send(event: EventData): Unit = {
       // Need to add a Seq No to the EventData to properly simulate the service.
-      val e = EventHubsTestUtils.createEventData(event.getBytes, data.size.toLong)
+      val e = EventHubsTestUtils.createEventData(event.getBytes, data.size.toLong, None)
       synchronized(data = data :+ e)
     }
 
-    private[utils] def size = synchronized(data.size)
+    private[spark] def size = synchronized(data.size)
 
     private[utils] def get(index: SequenceNumber): EventData = {
       data(index.toInt)

--- a/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsRelation.scala
@@ -47,11 +47,6 @@ private[eventhubs] class EventHubsRelation(override val sqlContext: SQLContext,
 
   override def schema: StructType = EventHubsSourceProvider.eventHubsSchema
 
-  private def serialize(x: AnyRef): String = {
-    implicit val formats = Serialization.formats(NoTypeHints)
-    Serialization.write(x)
-  }
-
   override def buildScan(): RDD[Row] = {
     val client = clientFactory(ehConf)
     val partitionCount: Int = client.partitionCount
@@ -90,7 +85,7 @@ private[eventhubs] class EventHubsRelation(override val sqlContext: SQLContext,
               UTF8String.fromString(ed.getSystemProperties.getPublisher),
               UTF8String.fromString(ed.getSystemProperties.getPartitionKey),
               ArrayBasedMapData(ed.getProperties.asScala.map { p =>
-                UTF8String.fromString(p._1) -> UTF8String.fromString(serialize(p._2))
+                UTF8String.fromString(p._1) -> UTF8String.fromString(Serialization.write(p._2))
               })
             )
           }

--- a/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsSource.scala
@@ -208,11 +208,6 @@ private[spark] class EventHubsSource private[eventhubs] (sqlContext: SQLContext,
     }
   }
 
-  private def serialize(x: AnyRef): String = {
-    implicit val formats = Serialization.formats(NoTypeHints)
-    Serialization.write(x)
-  }
-
   override def getBatch(start: Option[Offset], end: Offset): DataFrame = {
     initialPartitionSeqNos
 
@@ -290,7 +285,7 @@ private[spark] class EventHubsSource private[eventhubs] (sqlContext: SQLContext,
               UTF8String.fromString(ed.getSystemProperties.getPublisher),
               UTF8String.fromString(ed.getSystemProperties.getPartitionKey),
               ArrayBasedMapData(ed.getProperties.asScala.map { p =>
-                UTF8String.fromString(p._1) -> UTF8String.fromString(serialize(p._2))
+                UTF8String.fromString(p._1) -> UTF8String.fromString(Serialization.write(p._2))
               })
             )
           }

--- a/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsSource.scala
@@ -21,6 +21,17 @@ import java.io._
 import java.nio.charset.StandardCharsets
 
 import org.apache.commons.io.IOUtils
+import org.apache.qpid.proton.amqp.{
+  Binary,
+  Decimal128,
+  Decimal32,
+  Decimal64,
+  Symbol,
+  UnsignedByte,
+  UnsignedInteger,
+  UnsignedLong,
+  UnsignedShort
+}
 import org.apache.spark.SparkContext
 import org.apache.spark.eventhubs.client.Client
 import org.apache.spark.eventhubs.rdd.{ EventHubsRDD, OffsetRange }
@@ -284,9 +295,28 @@ private[spark] class EventHubsSource private[eventhubs] (sqlContext: SQLContext,
                 new java.sql.Timestamp(ed.getSystemProperties.getEnqueuedTime.toEpochMilli)),
               UTF8String.fromString(ed.getSystemProperties.getPublisher),
               UTF8String.fromString(ed.getSystemProperties.getPartitionKey),
-              ArrayBasedMapData(ed.getProperties.asScala.map { p =>
-                UTF8String.fromString(p._1) -> UTF8String.fromString(Serialization.write(p._2))
-              })
+              ArrayBasedMapData(
+                ed.getProperties.asScala
+                  .mapValues {
+                    case b: Binary =>
+                      val buf = b.asByteBuffer()
+                      val arr = new Array[Byte](buf.remaining)
+                      buf.get(arr)
+                      arr.asInstanceOf[AnyRef]
+                    case d128: Decimal128    => d128.asBytes.asInstanceOf[AnyRef]
+                    case d32: Decimal32      => d32.getBits.asInstanceOf[AnyRef]
+                    case d64: Decimal64      => d64.getBits.asInstanceOf[AnyRef]
+                    case s: Symbol           => s.toString.asInstanceOf[AnyRef]
+                    case ub: UnsignedByte    => ub.toString.asInstanceOf[AnyRef]
+                    case ui: UnsignedInteger => ui.toString.asInstanceOf[AnyRef]
+                    case ul: UnsignedLong    => ul.toString.asInstanceOf[AnyRef]
+                    case us: UnsignedShort   => us.toString.asInstanceOf[AnyRef]
+                    case c: Character        => c.toString.asInstanceOf[AnyRef]
+                    case default             => default
+                  }
+                  .map { p =>
+                    UTF8String.fromString(p._1) -> UTF8String.fromString(Serialization.write(p._2))
+                  })
             )
           }
         }

--- a/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsSource.scala
@@ -28,7 +28,7 @@ import org.apache.spark.eventhubs.{ EventHubsConf, NameAndPartition, _ }
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.ExecutorCacheTaskLocation
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.util.DateTimeUtils
+import org.apache.spark.sql.catalyst.util.{ ArrayBasedMapData, DateTimeUtils }
 import org.apache.spark.sql.execution.streaming.{
   HDFSMetadataLog,
   Offset,
@@ -38,6 +38,10 @@ import org.apache.spark.sql.execution.streaming.{
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{ DataFrame, SQLContext }
 import org.apache.spark.unsafe.types.UTF8String
+import org.json4s.NoTypeHints
+import org.json4s.jackson.Serialization
+
+import collection.JavaConverters._
 
 private[spark] class EventHubsSource private[eventhubs] (sqlContext: SQLContext,
                                                          options: Map[String, String],
@@ -204,6 +208,11 @@ private[spark] class EventHubsSource private[eventhubs] (sqlContext: SQLContext,
     }
   }
 
+  private def serialize(x: AnyRef): String = {
+    implicit val formats = Serialization.formats(NoTypeHints)
+    Serialization.write(x)
+  }
+
   override def getBatch(start: Option[Offset], end: Offset): DataFrame = {
     initialPartitionSeqNos
 
@@ -279,7 +288,10 @@ private[spark] class EventHubsSource private[eventhubs] (sqlContext: SQLContext,
               DateTimeUtils.fromJavaTimestamp(
                 new java.sql.Timestamp(ed.getSystemProperties.getEnqueuedTime.toEpochMilli)),
               UTF8String.fromString(ed.getSystemProperties.getPublisher),
-              UTF8String.fromString(ed.getSystemProperties.getPartitionKey)
+              UTF8String.fromString(ed.getSystemProperties.getPartitionKey),
+              ArrayBasedMapData(ed.getProperties.asScala.map { p =>
+                UTF8String.fromString(p._1) -> UTF8String.fromString(serialize(p._2))
+              })
             )
           }
         }

--- a/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsSourceProvider.scala
+++ b/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsSourceProvider.scala
@@ -156,7 +156,8 @@ private[sql] object EventHubsSourceProvider extends Serializable {
         StructField("sequenceNumber", LongType),
         StructField("enqueuedTime", TimestampType),
         StructField("publisher", StringType),
-        StructField("partitionKey", StringType)
+        StructField("partitionKey", StringType),
+        StructField("properties", MapType(StringType, StringType), nullable = true)
       ))
   }
 }

--- a/core/src/test/scala/org/apache/spark/eventhubs/rdd/EventHubsRDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubs/rdd/EventHubsRDDSuite.scala
@@ -35,11 +35,7 @@ class EventHubsRDDSuite extends SparkFunSuite with BeforeAndAfterAll {
     super.beforeAll()
     testUtils = new EventHubsTestUtils
     val eventHub = testUtils.createEventHubs(DefaultName, DefaultPartitionCount)
-
-    // Send events to simulated EventHubs
-    for (i <- 0 until DefaultPartitionCount) {
-      eventHub.send(i, 0 until 5000)
-    }
+    testUtils.populateUniformly(eventHub.name, 5000)
 
     sc = new SparkContext(sparkConf)
   }

--- a/core/src/test/scala/org/apache/spark/eventhubs/utils/EventHubsTestUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubs/utils/EventHubsTestUtilsSuite.scala
@@ -24,6 +24,8 @@ import org.apache.spark.eventhubs.{ EventHubsConf, NameAndPartition }
 import org.apache.spark.internal.Logging
 import org.scalatest.{ BeforeAndAfter, BeforeAndAfterAll, FunSuite }
 
+import collection.JavaConverters._
+
 /**
  * Tests the functionality of the simulated EventHubs instance used for testing.
  */
@@ -58,7 +60,7 @@ class EventHubsTestUtilsSuite
 
   test("Send one event to one partition") {
     val eventHub = testUtils.createEventHubs(newEventHubs(), DefaultPartitionCount)
-    eventHub.send(Some(0), Seq(0))
+    eventHub.send(Some(0), Seq(0), None)
 
     val data = eventHub.getPartitions
 
@@ -86,10 +88,10 @@ class EventHubsTestUtilsSuite
 
   test("All partitions have different data.") {
     val eventHub = testUtils.createEventHubs(newEventHubs(), DefaultPartitionCount)
-    eventHub.send(Some(0), Seq(1, 2, 3))
-    eventHub.send(Some(1), Seq(4, 5, 6))
-    eventHub.send(Some(2), Seq(7, 8, 9))
-    eventHub.send(Some(3), Seq(10, 11, 12))
+    eventHub.send(Some(0), Seq(1, 2, 3), None)
+    eventHub.send(Some(1), Seq(4, 5, 6), None)
+    eventHub.send(Some(2), Seq(7, 8, 9), None)
+    eventHub.send(Some(3), Seq(10, 11, 12), None)
 
     val data = eventHub.getPartitions
 
@@ -134,10 +136,10 @@ class EventHubsTestUtilsSuite
   test("latestSeqNo") {
     val eventHub = testUtils.createEventHubs(newEventHubs(), DefaultPartitionCount)
 
-    eventHub.send(Some(0), Seq(1))
-    eventHub.send(Some(1), Seq(2, 3))
-    eventHub.send(Some(2), Seq(4, 5, 6))
-    eventHub.send(Some(3), Seq(7))
+    eventHub.send(Some(0), Seq(1), None)
+    eventHub.send(Some(1), Seq(2, 3), None)
+    eventHub.send(Some(2), Seq(4, 5, 6), None)
+    eventHub.send(Some(3), Seq(7), None)
 
     val conf = testUtils.getEventHubsConf(eventHub.name)
     val client = SimulatedClient(conf)
@@ -155,10 +157,10 @@ class EventHubsTestUtilsSuite
     assert(eventHub.partitionSize(2) == 0)
     assert(eventHub.partitionSize(3) == 0)
 
-    eventHub.send(Some(0), Seq(1))
-    eventHub.send(Some(1), Seq(2, 3))
-    eventHub.send(Some(2), Seq(4, 5, 6))
-    eventHub.send(Some(3), Seq(7))
+    eventHub.send(Some(0), Seq(1), None)
+    eventHub.send(Some(1), Seq(2, 3), None)
+    eventHub.send(Some(2), Seq(4, 5, 6), None)
+    eventHub.send(Some(3), Seq(7), None)
 
     assert(eventHub.partitionSize(0) == 1)
     assert(eventHub.partitionSize(1) == 2)
@@ -171,10 +173,10 @@ class EventHubsTestUtilsSuite
 
     assert(eventHub.totalSize == 0)
 
-    eventHub.send(Some(0), Seq(1))
-    eventHub.send(Some(1), Seq(2, 3))
-    eventHub.send(Some(2), Seq(4, 5, 6))
-    eventHub.send(Some(3), Seq(7))
+    eventHub.send(Some(0), Seq(1), None)
+    eventHub.send(Some(1), Seq(2, 3), None)
+    eventHub.send(Some(2), Seq(4, 5, 6), None)
+    eventHub.send(Some(3), Seq(7), None)
 
     assert(eventHub.totalSize == 7)
   }
@@ -225,5 +227,42 @@ class EventHubsTestUtilsSuite
         .getBytes
         .sameElements(event.getBytes))
 
+  }
+
+  test("application properties - send") {
+    val eh = newEventHubs()
+    testUtils.createEventHubs(eh, partitionCount = 1)
+    val properties: Map[String, AnyRef] = Map(
+      "A" -> "1".getBytes,
+      "B" -> Map.empty,
+      "C" -> "Hello, world."
+    )
+    testUtils.send(eh, data = Seq(0), properties = Some(properties))
+    val event = testUtils.getEventHubs(eh).getPartitions(0).getEvents.head
+    assert(event.getProperties === properties.asJava)
+  }
+
+  test("application properties - partition send") {
+    val eh = newEventHubs()
+    testUtils.createEventHubs(eh, partitionCount = 2)
+    val properties: Map[String, AnyRef] = Map(
+      "A" -> "1".getBytes,
+      "B" -> Map.empty
+    )
+    testUtils.send(eh, partitionId = Some(1), Seq(0), Some(properties))
+    val event = testUtils.getEventHubs(eh).getPartitions(1).getEvents.head
+    assert(event.getProperties === properties.asJava)
+  }
+
+  test("application properties - populate uniformly") {
+    val eh = newEventHubs()
+    testUtils.createEventHubs(eh, partitionCount = 2)
+    val properties: Map[String, AnyRef] = Map(
+      "A" -> "1".getBytes,
+      "B" -> Map.empty
+    )
+    testUtils.populateUniformly(eh, 1, Some(properties))
+    val event = testUtils.getEventHubs(eh).getPartitions(0).getEvents.head
+    assert(event.getProperties === properties.asJava)
   }
 }

--- a/core/src/test/scala/org/apache/spark/eventhubs/utils/EventHubsTestUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubs/utils/EventHubsTestUtilsSuite.scala
@@ -58,7 +58,7 @@ class EventHubsTestUtilsSuite
 
   test("Send one event to one partition") {
     val eventHub = testUtils.createEventHubs(newEventHubs(), DefaultPartitionCount)
-    eventHub.send(0, Seq(0))
+    eventHub.send(Some(0), Seq(0))
 
     val data = eventHub.getPartitions
 
@@ -86,10 +86,10 @@ class EventHubsTestUtilsSuite
 
   test("All partitions have different data.") {
     val eventHub = testUtils.createEventHubs(newEventHubs(), DefaultPartitionCount)
-    eventHub.send(0, Seq(1, 2, 3))
-    eventHub.send(1, Seq(4, 5, 6))
-    eventHub.send(2, Seq(7, 8, 9))
-    eventHub.send(3, Seq(10, 11, 12))
+    eventHub.send(Some(0), Seq(1, 2, 3))
+    eventHub.send(Some(1), Seq(4, 5, 6))
+    eventHub.send(Some(2), Seq(7, 8, 9))
+    eventHub.send(Some(3), Seq(10, 11, 12))
 
     val data = eventHub.getPartitions
 
@@ -134,10 +134,10 @@ class EventHubsTestUtilsSuite
   test("latestSeqNo") {
     val eventHub = testUtils.createEventHubs(newEventHubs(), DefaultPartitionCount)
 
-    eventHub.send(0, Seq(1))
-    eventHub.send(1, Seq(2, 3))
-    eventHub.send(2, Seq(4, 5, 6))
-    eventHub.send(3, Seq(7))
+    eventHub.send(Some(0), Seq(1))
+    eventHub.send(Some(1), Seq(2, 3))
+    eventHub.send(Some(2), Seq(4, 5, 6))
+    eventHub.send(Some(3), Seq(7))
 
     val conf = testUtils.getEventHubsConf(eventHub.name)
     val client = SimulatedClient(conf)
@@ -155,10 +155,10 @@ class EventHubsTestUtilsSuite
     assert(eventHub.partitionSize(2) == 0)
     assert(eventHub.partitionSize(3) == 0)
 
-    eventHub.send(0, Seq(1))
-    eventHub.send(1, Seq(2, 3))
-    eventHub.send(2, Seq(4, 5, 6))
-    eventHub.send(3, Seq(7))
+    eventHub.send(Some(0), Seq(1))
+    eventHub.send(Some(1), Seq(2, 3))
+    eventHub.send(Some(2), Seq(4, 5, 6))
+    eventHub.send(Some(3), Seq(7))
 
     assert(eventHub.partitionSize(0) == 1)
     assert(eventHub.partitionSize(1) == 2)
@@ -171,10 +171,10 @@ class EventHubsTestUtilsSuite
 
     assert(eventHub.totalSize == 0)
 
-    eventHub.send(0, Seq(1))
-    eventHub.send(1, Seq(2, 3))
-    eventHub.send(2, Seq(4, 5, 6))
-    eventHub.send(3, Seq(7))
+    eventHub.send(Some(0), Seq(1))
+    eventHub.send(Some(1), Seq(2, 3))
+    eventHub.send(Some(2), Seq(4, 5, 6))
+    eventHub.send(Some(3), Seq(7))
 
     assert(eventHub.totalSize == 7)
   }

--- a/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsRelationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsRelationSuite.scala
@@ -67,9 +67,9 @@ class EventHubsRelationSuite extends QueryTest with BeforeAndAfter with SharedSQ
   test("default earliest to latest events") {
     val eh = newEventHub()
     testUtils.createEventHubs(eh, partitionCount = 3)
-    testUtils.send(eh, 0, 0 to 9)
-    testUtils.send(eh, 1, 10 to 19)
-    testUtils.send(eh, 2, 20 to 29)
+    testUtils.send(eh, partitionId = Some(0), data = 0 to 9)
+    testUtils.send(eh, partitionId = Some(1), data = 10 to 19)
+    testUtils.send(eh, partitionId = Some(2), data = 20 to 29)
 
     val ehConf = getEventHubsConf(eh)
       .setStartingPositions(Map.empty)
@@ -82,9 +82,9 @@ class EventHubsRelationSuite extends QueryTest with BeforeAndAfter with SharedSQ
   test("explicit earliest to latest events") {
     val eh = newEventHub()
     testUtils.createEventHubs(eh, partitionCount = 3)
-    testUtils.send(eh, 0, 0 to 9)
-    testUtils.send(eh, 1, 10 to 19)
-    testUtils.send(eh, 2, 20 to 29)
+    testUtils.send(eh, partitionId = Some(0), data = 0 to 9)
+    testUtils.send(eh, partitionId = Some(1), data = 10 to 19)
+    testUtils.send(eh, partitionId = Some(2), data = 20 to 29)
 
     val start = createPositions(0L, eh, partitionCount = 3)
     val end = createPositions(10L, eh, partitionCount = 3)
@@ -100,7 +100,7 @@ class EventHubsRelationSuite extends QueryTest with BeforeAndAfter with SharedSQ
   test("reuse same dataframe in query") {
     val eh = newEventHub()
     testUtils.createEventHubs(eh, partitionCount = 1)
-    testUtils.send(eh, 0, 0 to 10)
+    testUtils.send(eh, partitionId = Some(0), data = 0 to 10)
 
     val ehConf = getEventHubsConf(eh)
       .setStartingPositions(Map.empty)

--- a/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsRelationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsRelationSuite.scala
@@ -123,6 +123,11 @@ class EventHubsRelationSuite extends QueryTest with BeforeAndAfter with SharedSQ
         "O" -> new UnsignedLong(987654321L),
         "P" -> new UnsignedShort(Short.box(1))
       ))
+
+    // The expected serializes to:
+    //     [Map(E -> true, N -> "1", J -> "x-opt-partition-key", F -> 1, A -> "Hello, world.",
+    //     M -> 13, I -> [49], G -> 1, L -> 12, B -> {}, P -> "1", C -> [52,51,50], H -> "a",
+    //     K -> [0,1,2,3,0,0,0,0,0,1,2,3,0,0,0,0], O -> "987654321", D -> null)]
     val expected = properties.get
       .mapValues {
         case b: Binary =>

--- a/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsRelationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsRelationSuite.scala
@@ -19,10 +19,13 @@ package org.apache.spark.sql.eventhubs
 
 import java.util.concurrent.atomic.AtomicInteger
 
+import org.apache.qpid.proton.amqp.Binary
 import org.apache.spark.eventhubs.{ EventHubsConf, EventPosition, NameAndPartition }
 import org.apache.spark.eventhubs.utils.EventHubsTestUtils
 import org.apache.spark.sql.{ DataFrame, QueryTest }
 import org.apache.spark.sql.test.SharedSQLContext
+import org.json4s.NoTypeHints
+import org.json4s.jackson.Serialization
 import org.scalatest.BeforeAndAfter
 
 class EventHubsRelationSuite extends QueryTest with BeforeAndAfter with SharedSQLContext {
@@ -32,6 +35,8 @@ class EventHubsRelationSuite extends QueryTest with BeforeAndAfter with SharedSQ
   private val eventhubId = new AtomicInteger(0)
 
   private var testUtils: EventHubsTestUtils = _
+
+  implicit val formats = Serialization.formats(NoTypeHints)
 
   private def newEventHub(): String = s"eh-${eventhubId.getAndIncrement()}"
 
@@ -95,6 +100,46 @@ class EventHubsRelationSuite extends QueryTest with BeforeAndAfter with SharedSQ
 
     val df = createDF(ehConf)
     checkAnswer(df, (0 to 29).map(_.toString).toDF)
+  }
+
+  test("with application properties") {
+    val properties: Option[Map[String, Object]] = Some(
+      Map(
+        "A" -> "Hello, world.",
+        "B" -> Map.empty,
+        "C" -> "432".getBytes,
+        "D" -> null,
+        "E" -> Boolean.box(true),
+        "F" -> Int.box(1),
+        "G" -> Int.box(-1),
+        "H" -> Long.box(1L),
+        "I" -> Long.box(-1L),
+        "J" -> Short.box(1),
+        "K" -> Double.box(1),
+        "L" -> Float.box(3.4028235E38.toFloat),
+        "M" -> Char.box('a'),
+        "N" -> new Binary("1".getBytes),
+        "O" -> org.apache.qpid.proton.amqp.Symbol.getSymbol("x-opt-partition-key")
+      ))
+    val expected = properties.get.map { p =>
+      p._1 -> Serialization.write(p._2)
+    }
+
+    val eh = newEventHub()
+    testUtils.createEventHubs(eh, partitionCount = 3)
+    testUtils.send(eh, Some(0), 0 to 9, properties)
+
+    val ehConf = getEventHubsConf(eh)
+      .setStartingPositions(Map.empty)
+      .setEndingPositions(Map.empty)
+
+    val df = spark.read
+      .format("eventhubs")
+      .options(ehConf.toMap)
+      .load()
+      .select("properties")
+
+    checkAnswer(df, Seq.fill(10)(expected).toDF)
   }
 
   test("reuse same dataframe in query") {

--- a/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsSourceSuite.scala
@@ -21,7 +21,17 @@ import java.io.{ BufferedWriter, FileInputStream, OutputStream, OutputStreamWrit
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.concurrent.atomic.AtomicInteger
 
-import org.apache.qpid.proton.amqp.Binary
+import org.apache.qpid.proton.amqp.{
+  Binary,
+  Decimal128,
+  Decimal32,
+  Decimal64,
+  Symbol,
+  UnsignedByte,
+  UnsignedInteger,
+  UnsignedLong,
+  UnsignedShort
+}
 import org.apache.spark.eventhubs.utils.{ EventHubsTestUtils, SimulatedClient }
 import org.apache.spark.eventhubs.{ EventHubsConf, EventPosition, NameAndPartition }
 import org.apache.spark.sql.Dataset
@@ -496,19 +506,38 @@ class EventHubsSourceSuite extends EventHubsSourceTest {
         "D" -> null,
         "E" -> Boolean.box(true),
         "F" -> Int.box(1),
-        "G" -> Int.box(-1),
-        "H" -> Long.box(1L),
-        "I" -> Long.box(-1L),
-        "J" -> Short.box(1),
-        "K" -> Double.box(1),
-        "L" -> Float.box(3.4028235E38.toFloat),
-        "M" -> Char.box('a'),
-        "N" -> new Binary("1".getBytes),
-        "O" -> org.apache.qpid.proton.amqp.Symbol.getSymbol("x-opt-partition-key")
+        "G" -> Long.box(1L),
+        "H" -> Char.box('a'),
+        "I" -> new Binary("1".getBytes),
+        "J" -> Symbol.getSymbol("x-opt-partition-key"),
+        "K" -> new Decimal128(Array[Byte](0, 1, 2, 3, 0, 0, 0, 0, 0, 1, 2, 3, 0, 0, 0, 0)),
+        "L" -> new Decimal32(12),
+        "M" -> new Decimal64(13),
+        "N" -> new UnsignedByte(1.toByte),
+        "O" -> new UnsignedLong(987654321L),
+        "P" -> new UnsignedShort(Short.box(1))
       ))
-    val expected = properties.get.map { p =>
-      p._1 -> Serialization.write(p._2)
-    }
+    val expected = properties.get
+      .mapValues {
+        case b: Binary =>
+          val buf = b.asByteBuffer()
+          val arr = new Array[Byte](buf.remaining)
+          buf.get(arr)
+          arr.asInstanceOf[AnyRef]
+        case d128: Decimal128    => d128.asBytes.asInstanceOf[AnyRef]
+        case d32: Decimal32      => d32.getBits.asInstanceOf[AnyRef]
+        case d64: Decimal64      => d64.getBits.asInstanceOf[AnyRef]
+        case s: Symbol           => s.toString.asInstanceOf[AnyRef]
+        case ub: UnsignedByte    => ub.toString.asInstanceOf[AnyRef]
+        case ui: UnsignedInteger => ui.toString.asInstanceOf[AnyRef]
+        case ul: UnsignedLong    => ul.toString.asInstanceOf[AnyRef]
+        case us: UnsignedShort   => us.toString.asInstanceOf[AnyRef]
+        case c: Character        => c.toString.asInstanceOf[AnyRef]
+        case default             => default
+      }
+      .map { p =>
+        p._1 -> Serialization.write(p._2)
+      }
 
     val eventHub = testUtils.createEventHubs(newEventHubs(), partitionCount = 1)
     testUtils.populateUniformly(eventHub.name, 5000, properties)

--- a/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsSourceSuite.scala
@@ -21,6 +21,7 @@ import java.io.{ BufferedWriter, FileInputStream, OutputStream, OutputStreamWrit
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.concurrent.atomic.AtomicInteger
 
+import org.apache.qpid.proton.amqp.Binary
 import org.apache.spark.eventhubs.utils.{ EventHubsTestUtils, SimulatedClient }
 import org.apache.spark.eventhubs.{ EventHubsConf, EventPosition, NameAndPartition }
 import org.apache.spark.sql.Dataset
@@ -30,12 +31,16 @@ import org.apache.spark.sql.streaming.util.StreamManualClock
 import org.apache.spark.sql.streaming.{ ProcessingTime, StreamTest }
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.util.Utils
+import org.json4s.NoTypeHints
+import org.json4s.jackson.Serialization
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.time.SpanSugar._
 
 abstract class EventHubsSourceTest extends StreamTest with SharedSQLContext {
 
   protected var testUtils: EventHubsTestUtils = _
+
+  implicit val formats = Serialization.formats(NoTypeHints)
 
   override def beforeAll: Unit = {
     super.beforeAll
@@ -479,6 +484,68 @@ class EventHubsSourceSuite extends EventHubsSourceTest {
       AddEventHubsData(conf, 30, 31, 32, 33, 34),
       CheckAnswer(-20, -21, -22, 0, 1, 2, 11, 12, 22, 30, 31, 32, 33, 34),
       StopStream
+    )
+  }
+
+  test("with application properties") {
+    val properties: Option[Map[String, Object]] = Some(
+      Map(
+        "A" -> "Hello, world.",
+        "B" -> Map.empty,
+        "C" -> "432".getBytes,
+        "D" -> null,
+        "E" -> Boolean.box(true),
+        "F" -> Int.box(1),
+        "G" -> Int.box(-1),
+        "H" -> Long.box(1L),
+        "I" -> Long.box(-1L),
+        "J" -> Short.box(1),
+        "K" -> Double.box(1),
+        "L" -> Float.box(3.4028235E38.toFloat),
+        "M" -> Char.box('a'),
+        "N" -> new Binary("1".getBytes),
+        "O" -> org.apache.qpid.proton.amqp.Symbol.getSymbol("x-opt-partition-key")
+      ))
+    val expected = properties.get.map { p =>
+      p._1 -> Serialization.write(p._2)
+    }
+
+    val eventHub = testUtils.createEventHubs(newEventHubs(), partitionCount = 1)
+    testUtils.populateUniformly(eventHub.name, 5000, properties)
+
+    val parameters =
+      getEventHubsConf(eventHub.name)
+        .setMaxEventsPerTrigger(1)
+        .toMap
+
+    val reader = spark.readStream
+      .format("eventhubs")
+      .options(parameters)
+
+    val eventhubs = reader
+      .load()
+      .select("properties")
+      .as[Map[String, String]]
+
+    val clock = new StreamManualClock
+
+    val waitUntilBatchProcessed = AssertOnQuery { q =>
+      eventually(Timeout(streamingTimeout)) {
+        if (q.exception.isEmpty) {
+          assert(clock.isStreamWaitingAt(clock.getTimeMillis()))
+        }
+      }
+      if (q.exception.isDefined) {
+        throw q.exception.get
+      }
+      true
+    }
+
+    testStream(eventhubs)(
+      StartStream(ProcessingTime(100), clock),
+      waitUntilBatchProcessed,
+      // we'll get one event per partition per trigger
+      CheckAnswer(expected)
     )
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsSourceSuite.scala
@@ -517,6 +517,11 @@ class EventHubsSourceSuite extends EventHubsSourceTest {
         "O" -> new UnsignedLong(987654321L),
         "P" -> new UnsignedShort(Short.box(1))
       ))
+
+    // The expected serializes to:
+    //     [Map(E -> true, N -> "1", J -> "x-opt-partition-key", F -> 1, A -> "Hello, world.",
+    //     M -> 13, I -> [49], G -> 1, L -> 12, B -> {}, P -> "1", C -> [52,51,50], H -> "a",
+    //     K -> [0,1,2,3,0,0,0,0,0,1,2,3,0,0,0,0], O -> "987654321", D -> null)]
     val expected = properties.get
       .mapValues {
         case b: Binary =>

--- a/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsSourceSuite.scala
@@ -558,6 +558,7 @@ class EventHubsSourceSuite extends EventHubsSourceTest {
     // producer. So here we just use a low bound to make sure the internal conversion works.
     assert(row.getAs[java.sql.Timestamp]("enqueuedTime").getTime >= now,
            s"Unexpected results: $row")
+    assert(row.getAs[Map[String, String]]("properties") === Map(), s"Unexpected results: $row")
     query.stop()
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsSourceSuite.scala
@@ -83,7 +83,7 @@ abstract class EventHubsSourceTest extends StreamTest with SharedSQLContext {
       }
 
       val ehSource = sources.head
-      testUtils.send(conf.name, data)
+      testUtils.send(conf.name, data = data)
 
       val seqNos = testUtils.getLatestSeqNos(conf)
       require(seqNos.size == testUtils.getEventHubs(conf.name).partitionCount)
@@ -251,9 +251,9 @@ class EventHubsSourceSuite extends EventHubsSourceTest {
     val name = newEventHubs()
     val eventHub = testUtils.createEventHubs(name, DefaultPartitionCount)
 
-    testUtils.send(name, 0, 100 to 200)
-    testUtils.send(name, 1, 10 to 20)
-    testUtils.send(name, 2, Seq(1))
+    testUtils.send(name, partitionId = Some(0), data = 100 to 200)
+    testUtils.send(name, partitionId = Some(1), data = 10 to 20)
+    testUtils.send(name, partitionId = Some(2), data = Seq(1))
     // partition 3 of 3 remains empty.
 
     val parameters =
@@ -352,7 +352,7 @@ class EventHubsSourceSuite extends EventHubsSourceTest {
 
   private def testFromLatestSeqNos(eh: String): Unit = {
     val eventHub = testUtils.createEventHubs(eh, DefaultPartitionCount)
-    testUtils.send(eh, 0, Seq(-1))
+    testUtils.send(eh, partitionId = Some(0), Seq(-1))
 
     require(testUtils.getEventHubs(eh).getPartitions.size === 4)
 
@@ -401,7 +401,7 @@ class EventHubsSourceSuite extends EventHubsSourceTest {
     val eventHub = testUtils.createEventHubs(eh, DefaultPartitionCount)
 
     require(testUtils.getEventHubs(eh).getPartitions.size === 4)
-    testUtils.send(eh, 1 to 3) // round robin events across partitions
+    testUtils.send(eh, data = 1 to 3) // round robin events across partitions
 
     val conf = getEventHubsConf(eh)
 
@@ -449,15 +449,15 @@ class EventHubsSourceSuite extends EventHubsSourceTest {
       .setStartingPositions(positions)
 
     // partition 0 starts at the earliest sequence numbers, these should all be seen
-    testUtils.send(eh, 0, Seq(-20, -21, -22))
+    testUtils.send(eh, partitionId = Some(0), Seq(-20, -21, -22))
     // partition 1 starts at the latest sequence numbers, these should all be skipped
-    testUtils.send(eh, 1, Seq(-10, -11, -12))
+    testUtils.send(eh, partitionId = Some(1), Seq(-10, -11, -12))
     // partition 2 starts at 0, these should all be seen
-    testUtils.send(eh, 2, Seq(0, 1, 2))
+    testUtils.send(eh, partitionId = Some(2), Seq(0, 1, 2))
     // partition 3 starts at 1, first should be skipped
-    testUtils.send(eh, 3, Seq(10, 11, 12))
+    testUtils.send(eh, partitionId = Some(3), Seq(10, 11, 12))
     // partition 4 starts at 2, first and second should be skipped
-    testUtils.send(eh, 4, Seq(20, 21, 22))
+    testUtils.send(eh, partitionId = Some(4), Seq(20, 21, 22))
 
     val reader = spark.readStream
       .format("eventhubs")
@@ -486,7 +486,7 @@ class EventHubsSourceSuite extends EventHubsSourceTest {
     val eh = newEventHubs()
     val eventHub = testUtils.createEventHubs(eh, DefaultPartitionCount)
 
-    testUtils.send(eh, Seq(-1))
+    testUtils.send(eh, data = Seq(-1))
     require(testUtils.getEventHubs(eh).getPartitions.size === 4)
 
     val positions = Map(
@@ -531,7 +531,7 @@ class EventHubsSourceSuite extends EventHubsSourceTest {
 
     require(testUtils.getEventHubs(eh).getPartitions.size === 1)
 
-    testUtils.send(eh, Seq(1))
+    testUtils.send(eh, data = Seq(1))
 
     val eventhubs = spark.readStream
       .format("eventhubs")
@@ -573,7 +573,7 @@ class EventHubsSourceSuite extends EventHubsSourceTest {
 
     require(testUtils.getEventHubs(eh).getPartitions.size === 1)
 
-    testUtils.send(eh, Seq(1))
+    testUtils.send(eh, data = Seq(1))
 
     val eventhubs = spark.readStream
       .format("eventhubs")

--- a/docs/PySpark/structured-streaming-pyspark.md
+++ b/docs/PySpark/structured-streaming-pyspark.md
@@ -12,6 +12,7 @@
   * [Creating an Event Hubs Sink for Streaming Queries](#creating-an-eventhubs-sink-for-streaming-queries)
   * [Writing the output of Batch Queries to Event Hubs](#writing-the-output-of-batch-queries-to-event-hubs)
 * [Managing Throughput](#managing-throughput)
+* [Serialization of Event Data Properties](#serialization-of-event-data-properties)
 * [Deploying](#deploying)
 
 ## Linking

--- a/docs/PySpark/structured-streaming-pyspark.md
+++ b/docs/PySpark/structured-streaming-pyspark.md
@@ -343,7 +343,23 @@ from your Event Hub without being throttled. If `maxEventsPerTrigger` is set suc
 will happen within a second. You're free to leave it as such or you can increase your `maxEventsPerTrigger` up to 2 MB per second.
 If `maxEventsPerTrigger` is set such that Spark consumes *greater than 2 MB*, your micro-batch will always take more than one second
 to be created because consuming from Event Hubs will always take at least one second. You're free to leave it as is or you can increase
-your TUs to increase throughput. 
+your TUs to increase throughput.
+
+## Serialization of Event Data Properties
+
+Users can pass custom key-value properties in their `EventData`. These properties are exposed in the Spark SQL schema. Keys
+are exposed as strings, and values are exposed as json-serialized strings. Native types are supported out of the box. Custom
+AMQP types need to be handled explicitly by the connector. Below we list the AMQP types we support and how they are handled:
+
+- `Binary` - the underlying byte array is serialized.
+- `Decimal128` - the underlying byte array is serialized.
+- `Decimal32` - the underlying integer representation is serialized.
+- `Decimal64` - the underlying long representation is serialized.
+- `Symbol` - the underlying string is serialized.
+- `UnsignedByte` - the underlying string is serialized.
+- `UnsignedInteger` - the underlying string is serialized.
+- `UnsignedLong` - the underlying string is serialized.
+- `UnsignedShort` - the underlying string is serialized.
 
 ## Deploying 
 

--- a/docs/structured-streaming-eventhubs-integration.md
+++ b/docs/structured-streaming-eventhubs-integration.md
@@ -14,6 +14,7 @@ Structured Streaming integration for Azure Event Hubs to read data from Event Hu
   * [Creating an EventHubs Sink for Streaming Queries](#creating-an-eventhubs-sink-for-streaming-queries)
   * [Writing the output of Batch Queries to EventHubs](#writing-the-output-of-batch-queries-to-eventhubs)
 * [Managing Throughput](#managing-throughput)
+* [Serialization of Event Data Properties](#serialization-of-event-data-properties)
 * [Deploying](#deploying)
 
 ## Linking

--- a/docs/structured-streaming-eventhubs-integration.md
+++ b/docs/structured-streaming-eventhubs-integration.md
@@ -342,9 +342,25 @@ from your Event Hub without being throttled. If `maxEventsPerTrigger` is set suc
 will happen within a second. You're free to leave it as such or you can increase your `maxEventsPerTrigger` up to 2 MB per second.
 If `maxEventsPerTrigger` is set such that Spark consumes *greater than 2 MB*, your micro-batch will always take more than one second
 to be created because consuming from Event Hubs will always take at least one second. You're free to leave it as is or you can increase
-your TUs to increase throughput. 
+your TUs to increase throughput.
 
-## Deploying 
+## Serialization of Event Data Properties
+
+Users can pass custom key-value properties in their `EventData`. These properties are exposed in the Spark SQL schema. Keys
+are exposed as strings, and values are exposed as json-serialized strings. Native types are supported out of the box. Custom
+AMQP types need to be handled explicitly by the connector. Below we list the AMQP types we support and how they are handled:
+
+- `Binary` - the underlying byte array is serialized.
+- `Decimal128` - the underlying byte array is serialized.
+- `Decimal32` - the underlying integer representation is serialized.
+- `Decimal64` - the underlying long representation is serialized.
+- `Symbol` - the underlying string is serialized.
+- `UnsignedByte` - the underlying string is serialized.
+- `UnsignedInteger` - the underlying string is serialized.
+- `UnsignedLong` - the underlying string is serialized.
+- `UnsignedShort` - the underlying string is serialized.
+
+## Deploying
 
 As with any Spark applications, `spark-submit` is used to launch your application. `azure-eventhubs-spark_2.11`
 and its dependencies can be directly added to `spark-submit` using `--packages`, such as,

--- a/docs/structured-streaming-eventhubs-integration.md
+++ b/docs/structured-streaming-eventhubs-integration.md
@@ -260,7 +260,8 @@ Each row in the source has the following schema:
 | sequenceNumber | long |
 | enqueuedTime | timestamp |
 | publisher | string |
-| partitionKey | string | 
+| partitionKey | string |
+| properties | map[string, json] |
 
 ## Writing Data to EventHubs
 


### PR DESCRIPTION
close #250 

This adds properties to the Spark SQL schema in the form of a `Map[String, String]`. Where the values are all serialized as JSON strings. This uses json4s and jackson (as does Spark). 