### PR TITLE
Trim EventHubsConf before sending to Spark Executors

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubs/EventHubsConf.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/EventHubsConf.scala
@@ -71,6 +71,11 @@ final class EventHubsConf private (private val connectionStr: String)
     this
   }
 
+  private def remove(key: String): EventHubsConf = {
+    settings.remove(key)
+    this
+  }
+
   private[spark] def apply(key: String): String = {
     get(key).get
   }
@@ -375,6 +380,23 @@ object EventHubsConf extends Logging {
 
   private def write[T <: AnyRef](value: T): String = {
     Serialization.write[T](value)
+  }
+
+  /**
+   * This method removes all parameters that aren't needed by Spark executors.
+   *
+   * @param ehConf the [[EventHubsConf]] that will be trimmed
+   * @return trimmed [[EventHubsConf]]
+   */
+  private[spark] def trim(ehConf: EventHubsConf): EventHubsConf = {
+    ehConf
+      .remove("eventhubs.startingPosition")
+      .remove("eventhubs.startingPositions")
+      .remove("eventhubs.endingPosition")
+      .remove("eventhubs.endingPositions")
+      .remove("eventhubs.maxRatePerPartition")
+      .remove("eventhubs.maxRatesPerPartition")
+      .remove("maxEventsPerTrigger")
   }
 
   // Option key values

--- a/core/src/main/scala/org/apache/spark/eventhubs/EventHubsUtils.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/EventHubsUtils.scala
@@ -66,7 +66,7 @@ object EventHubsUtils {
   def createRDD(sc: SparkContext,
                 ehConf: EventHubsConf,
                 offsetRanges: Array[OffsetRange]): EventHubsRDD = {
-    new EventHubsRDD(sc, ehConf, offsetRanges)
+    new EventHubsRDD(sc, EventHubsConf.trim(ehConf), offsetRanges)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsRelation.scala
@@ -68,7 +68,7 @@ private[eventhubs] class EventHubsRelation(override val sqlContext: SQLContext,
       "GetBatch generating RDD of with offsetRanges: " +
         offsetRanges.sortBy(_.nameAndPartition.toString).mkString(", "))
 
-    val rdd = new EventHubsRDD(sqlContext.sparkContext, ehConf, offsetRanges)
+    val rdd = new EventHubsRDD(sqlContext.sparkContext, EventHubsConf.trim(ehConf), offsetRanges)
       .mapPartitionsWithIndex { (p, iter) =>
         {
           iter.map { ed =>

--- a/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsSource.scala
@@ -267,7 +267,7 @@ private[spark] class EventHubsSource private[eventhubs] (sqlContext: SQLContext,
       }
     }.toArray
 
-    val rdd = new EventHubsRDD(sc, ehConf, offsetRanges)
+    val rdd = new EventHubsRDD(sc, EventHubsConf.trim(ehConf), offsetRanges)
       .mapPartitionsWithIndex { (p, iter) =>
         {
           iter.map { ed =>

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubsDirectDStream.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubsDirectDStream.scala
@@ -108,7 +108,7 @@ private[spark] class EventHubsDirectDStream private[spark] (
     } yield
       OffsetRange(NameAndPartition(ehName, p), fromSeqNos(p), untilSeqNos(p), preferredLoc)).toArray
 
-    val rdd = new EventHubsRDD(context.sparkContext, ehConf, offsetRanges)
+    val rdd = new EventHubsRDD(context.sparkContext, EventHubsConf.trim(ehConf), offsetRanges)
 
     val description = offsetRanges.map(_.toString).mkString("\n")
     logInfo(s"Starting batch at $validTime for EH: $ehName with\n $description")
@@ -153,7 +153,7 @@ private[spark] class EventHubsDirectDStream private[spark] (
         case (t, b) =>
           logInfo(s"Restoring EventHubsRDD for time $t ${b.mkString("[", ", ", "]")}")
           generatedRDDs += t -> new EventHubsRDD(context.sparkContext,
-                                                 ehConf,
+                                                 EventHubsConf.trim(ehConf),
                                                  b.map(OffsetRange(_)))
       }
     }

--- a/core/src/test/scala/org/apache/spark/eventhubs/rdd/EventHubsRDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubs/rdd/EventHubsRDDSuite.scala
@@ -68,7 +68,7 @@ class EventHubsRDDSuite extends SparkFunSuite with BeforeAndAfterAll {
       partition <- 0 until DefaultPartitionCount
     } yield OffsetRange(ehConf.name, partition, fromSeqNo, untilSeqNo, None)).toArray
 
-    val rdd = new EventHubsRDD(sc, ehConf, offsetRanges)
+    val rdd = new EventHubsRDD(sc, EventHubsConf.trim(ehConf), offsetRanges)
       .map(_.getBytes.map(_.toChar).mkString)
 
     assert(rdd.count == (untilSeqNo - fromSeqNo) * DefaultPartitionCount)
@@ -88,7 +88,7 @@ class EventHubsRDDSuite extends SparkFunSuite with BeforeAndAfterAll {
       partition <- 0 until DefaultPartitionCount
     } yield OffsetRange(ehConf.name, partition, fromSeqNo, untilSeqNo, None)).toArray
 
-    val rdd = new EventHubsRDD(sc, ehConf, offsetRanges)
+    val rdd = new EventHubsRDD(sc, EventHubsConf.trim(ehConf), offsetRanges)
       .map(_.getBytes.map(_.toChar).mkString)
 
     assert(rdd.count == (untilSeqNo - fromSeqNo) * DefaultPartitionCount)
@@ -106,7 +106,7 @@ class EventHubsRDDSuite extends SparkFunSuite with BeforeAndAfterAll {
 
     val offsetRanges = Array(OffsetRange(ehConf.name, 0, fromSeqNo, untilSeqNo, None))
 
-    val rdd = new EventHubsRDD(sc, ehConf, offsetRanges)
+    val rdd = new EventHubsRDD(sc, EventHubsConf.trim(ehConf), offsetRanges)
       .map(_.getSystemProperties.getSequenceNumber)
 
     assert(rdd.count == (untilSeqNo - fromSeqNo)) // no PartitionCount multiplier b/c we only have one partition
@@ -128,7 +128,7 @@ class EventHubsRDDSuite extends SparkFunSuite with BeforeAndAfterAll {
       partition <- 0 until DefaultPartitionCount
     } yield OffsetRange(ehConf.name, partition, fromSeqNo, untilSeqNo, None)).toArray
 
-    val rdd = new EventHubsRDD(sc, ehConf, offsetRanges)
+    val rdd = new EventHubsRDD(sc, EventHubsConf.trim(ehConf), offsetRanges)
       .map(_.getBytes.map(_.toChar).mkString)
       .repartition(20)
 


### PR DESCRIPTION
Removes all the options that are never used by Spark Executors. Just a simple optimization so we aren't sending too much info across the Spark cluster. 

close #258 