### PR TITLE
Trim executor options based on included options

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubs/EventHubsConf.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/EventHubsConf.scala
@@ -389,14 +389,15 @@ object EventHubsConf extends Logging {
    * @return trimmed [[EventHubsConf]]
    */
   private[spark] def trim(ehConf: EventHubsConf): EventHubsConf = {
+    // These are the options needed by Spark executors
+    val include = Seq("eventhubs.connectionString",
+                      "eventhubs.consumerGroup",
+                      "eventhubs.receiverTimeout",
+                      "eventhubs.operationTimeout",
+                      "useSimulatedClient")
+
+    ehConf.settings.asScala.filter(tuple => include.contains(tuple._1))
     ehConf
-      .remove("eventhubs.startingPosition")
-      .remove("eventhubs.startingPositions")
-      .remove("eventhubs.endingPosition")
-      .remove("eventhubs.endingPositions")
-      .remove("eventhubs.maxRatePerPartition")
-      .remove("eventhubs.maxRatesPerPartition")
-      .remove("maxEventsPerTrigger")
   }
 
   // Option key values


### PR DESCRIPTION
Trimming options based on included options (not excluded options). When new params are added, they'll need to be explicitly added to the `include` list in order to be passed to executors. This ensures we don't accidentally pass unneeded options to executors by mistake. 👍  