### PR TITLE
Fix option trimming bug

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubs/EventHubsConf.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/EventHubsConf.scala
@@ -405,10 +405,12 @@ object EventHubsConf extends Logging {
                       "eventhubs.consumerGroup",
                       "eventhubs.receiverTimeout",
                       "eventhubs.operationTimeout",
-                      "useSimulatedClient")
+                      "useSimulatedClient").map(s => s.toLowerCase)
 
-    ehConf.settings.asScala.filter(tuple => include.contains(tuple._1))
-    ehConf
+    val filtered = ehConf.settings.asScala.filter(k => include.contains(k._1))
+    val newConf = EventHubsConf(ehConf.connectionString)
+    for ((k, v) <- filtered) { newConf.set(k, v) }
+    newConf
   }
 
   // Option key values


### PR DESCRIPTION
Now when we trim options in `EventHubsConf` we make a new conf with less options and return that (while keeping the original conf unmodified). 