### PR TITLE
Translate redo and parallelize getOffset

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubs/EventPosition.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/EventPosition.scala
@@ -62,8 +62,6 @@ case class EventPosition private (offset: String = null,
  * Companion object to help create [[EventPosition]] instances.
  */
 object EventPosition {
-  private val StartOfStream: String = "-1"
-  private val EndOfStream: String = "@latest"
 
   /**
    * Creates a position at the given offset. When using EventHubs with Spark,

--- a/core/src/main/scala/org/apache/spark/eventhubs/client/Client.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/client/Client.scala
@@ -81,6 +81,15 @@ private[spark] trait Client extends Serializable {
   def boundedSeqNos(partition: PartitionId): (SequenceNumber, SequenceNumber)
 
   /**
+   * Similar to [[boundedSeqNos()]] except the information is collected for all
+   * partitions.
+   *
+   * @param partitionCount the number of partitions in the Event Hub instance
+   * @return the earliest and latest sequence numbers for all partitions in the Event Hub
+   */
+  def allBoundedSeqNos(partitionCount: Int): Seq[(PartitionId, (SequenceNumber, SequenceNumber))]
+
+  /**
    * Translates all [[EventPosition]]s provided in the [[EventHubsConf]] to
    * sequence numbers. Sequence numbers are zero-based indices. The 5th event
    * in an Event Hubs partition will have a sequence number of 4.

--- a/core/src/main/scala/org/apache/spark/eventhubs/client/EventHubsClient.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/client/EventHubsClient.scala
@@ -86,7 +86,7 @@ private[spark] class EventHubsClient(private val ehConf: EventHubsConf)
 
   @annotation.tailrec
   final def retry[T](n: Int)(method: String)(fn: => T): T = {
-    logInfo(s"retry: attempt $n")
+    logInfo(s"retry: $method: attempts left: $n")
     Try { fn } match {
       case Success(x) => x
       case Failure(e: EventHubException) if e.getIsTransient && n > 1 =>

--- a/core/src/main/scala/org/apache/spark/eventhubs/package.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/package.scala
@@ -18,11 +18,12 @@
 package org.apache.spark
 
 import java.time.Duration
-import java.util.concurrent.{ ExecutorService, Executors }
 
 import com.microsoft.azure.eventhubs.{ EventHubClient, PartitionReceiver }
 import org.json4s.NoTypeHints
 import org.json4s.jackson.Serialization
+
+import scala.concurrent.duration._
 
 /**
  * A package object to constants, implicit conversion, and type
@@ -32,6 +33,8 @@ package object eventhubs {
 
   implicit val formats = Serialization.formats(NoTypeHints)
 
+  val StartOfStream: String = "-1"
+  val EndOfStream: String = "@latest"
   val DefaultEventPosition: EventPosition = EventPosition.fromEndOfStream
   val DefaultEndingPosition: EventPosition = EventPosition.fromEndOfStream
   val DefaultMaxRatePerPartition: Rate = 1000
@@ -45,6 +48,7 @@ package object eventhubs {
   val StartingSequenceNumber = 0L
   val DefaultEpoch = 0L
   val RetryCount = 3
+  val InternalOperationTimeout = 300.seconds
 
   type PartitionId = Int
   val PartitionId = Int

--- a/core/src/main/scala/org/apache/spark/eventhubs/utils/EventHubsTestUtils.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/utils/EventHubsTestUtils.scala
@@ -525,6 +525,17 @@ private[spark] class SimulatedClient(private val ehConf: EventHubsConf) extends 
   }
 
   /**
+   * Same as boundedSeqNos, but collects info for all partitions.
+   *
+   * @param partitionCount the number of partitions in the Event Hub instance
+   * @return the earliest and latest sequence numbers for all partitions in the Event Hub
+   */
+  override def allBoundedSeqNos(
+      partitionCount: Int): Seq[(PartitionId, (SequenceNumber, SequenceNumber))] = {
+    for (i <- 0 until partitionCount) yield (i, (earliestSeqNo(i), latestSeqNo(i)))
+  }
+
+  /**
    * Translates starting (or ending) positions to sequence numbers.
    *
    * @param ehConf the [[EventHubsConf]] containing starting (or ending positions)

--- a/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsSource.scala
@@ -167,8 +167,7 @@ private[spark] class EventHubsSource private[eventhubs] (sqlContext: SQLContext,
 
     // This contains an array of the following elements:
     // (partition, (earliestSeqNo, latestSeqNo)
-    val futures = for { p <- 0 until partitionCount } yield Future(p, ehClient.boundedSeqNos(p))
-    val earliestAndLatest = Await.result(Future.sequence(futures), InternalOperationTimeout)
+    val earliestAndLatest = ehClient.allBoundedSeqNos(partitionCount)
 
     // There is a possibility that data from EventHubs will
     // expire before it can be consumed from Spark. We collect

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubsDirectDStream.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubsDirectDStream.scala
@@ -82,10 +82,13 @@ private[spark] class EventHubsDirectDStream private[spark] (
   }
 
   protected def latestSeqNos(): Map[PartitionId, SequenceNumber] = {
-    (for {
-      partitionId <- 0 until partitionCount
-      endPoint = ehClient.latestSeqNo(partitionId)
-    } yield partitionId -> endPoint).toMap
+    ehClient
+      .allBoundedSeqNos(partitionCount)
+      .map {
+        case (p, (_, l)) =>
+          (p, l)
+      }
+      .toMap
   }
 
   protected def clamp(

--- a/core/src/test/scala/org/apache/spark/eventhubs/utils/EventHubsTestUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubs/utils/EventHubsTestUtilsSuite.scala
@@ -149,6 +149,55 @@ class EventHubsTestUtilsSuite
     assert(client.latestSeqNo(3) == 1)
   }
 
+  test("earliestSeqNo") {
+    val eventHub = testUtils.createEventHubs(newEventHubs(), DefaultPartitionCount)
+
+    eventHub.send(Some(0), Seq(1), None)
+    eventHub.send(Some(1), Seq(2, 3), None)
+    eventHub.send(Some(2), Seq(4, 5, 6), None)
+    eventHub.send(Some(3), Seq(7), None)
+
+    val conf = testUtils.getEventHubsConf(eventHub.name)
+    val client = SimulatedClient(conf)
+    assert(client.earliestSeqNo(0) == 0)
+    assert(client.earliestSeqNo(1) == 0)
+    assert(client.earliestSeqNo(2) == 0)
+    assert(client.earliestSeqNo(3) == 0)
+  }
+
+  test("boundedSeqNo") {
+    val eventHub = testUtils.createEventHubs(newEventHubs(), DefaultPartitionCount)
+
+    eventHub.send(Some(0), Seq(1), None)
+    eventHub.send(Some(1), Seq(2, 3), None)
+    eventHub.send(Some(2), Seq(4, 5, 6), None)
+    eventHub.send(Some(3), Seq(7), None)
+
+    val conf = testUtils.getEventHubsConf(eventHub.name)
+    val client = SimulatedClient(conf)
+    assert(client.boundedSeqNos(0) == (0, 1))
+    assert(client.boundedSeqNos(1) == (0, 2))
+    assert(client.boundedSeqNos(2) == (0, 3))
+    assert(client.boundedSeqNos(3) == (0, 1))
+  }
+
+  test("allBoundedSeqNo") {
+    val eventHub = testUtils.createEventHubs(newEventHubs(), DefaultPartitionCount)
+
+    eventHub.send(Some(0), Seq(1), None)
+    eventHub.send(Some(1), Seq(2, 3), None)
+    eventHub.send(Some(2), Seq(4, 5, 6), None)
+    eventHub.send(Some(3), Seq(7), None)
+
+    val conf = testUtils.getEventHubsConf(eventHub.name)
+    val client = SimulatedClient(conf)
+    val results = client.allBoundedSeqNos(eventHub.partitionCount).toMap
+    assert(results(0) == (0, 1))
+    assert(results(1) == (0, 2))
+    assert(results(2) == (0, 3))
+    assert(results(3) == (0, 1))
+  }
+
   test("partitionSize") {
     val eventHub = testUtils.createEventHubs(newEventHubs(), DefaultPartitionCount)
 

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.scala-lang.modules</groupId>
+      <artifactId>scala-java8-compat_2.11</artifactId>
+      <version>0.9.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>1.10.8</version>


### PR DESCRIPTION
- Translate has been rewritten. Now - in most cases - receivers are no longer created. If `EndOfStream` or `StartOfStream` are passed by the user, then we just cut to the chase and call `getLatest` or `getEarliest` to get the sequence number (rather than creating a receiver). 

- getOffset now does the `getRunTimeInfo` calls in parallel