### PR TITLE
Finalize move to async service calls

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubs/client/CachedEventHubsReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/client/CachedEventHubsReceiver.scala
@@ -102,13 +102,12 @@ private[client] class CachedEventHubsReceiver private (ehConf: EventHubsConf,
       i = try {
         receiver.receiveSync(1)
       } catch {
-        case r: ReceiverDisconnectedException => {
+        case r: ReceiverDisconnectedException =>
           throw new Exception(
             "You are likely running multiple Spark jobs with the same consumer group. " +
               "For each Spark job, please create and use a unique consumer group to avoid this issue.",
             r
           )
-        }
       }
     }
     event = i.iterator.next

--- a/core/src/main/scala/org/apache/spark/eventhubs/client/Client.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/client/Client.scala
@@ -54,40 +54,12 @@ private[spark] trait Client extends Serializable {
            partitionKey: Option[String] = None): Unit
 
   /**
-   * Provides the earliest (lowest) sequence number that exists in the
-   * EventHubs instance for the given partition.
+   * Returns the earliest and latest sequence numbers for all partitions
+   * in an Event Hub.
    *
-   * @param partition the partition that will be queried
-   * @return the earliest sequence number for the specified partition
-   */
-  def earliestSeqNo(partition: PartitionId): SequenceNumber
-
-  /**
-   * Provides the latest (highest) sequence number that exists in the EventHubs
-   * instance for the given partition.
-   *
-   * @param partition the partition that will be queried
-   * @return the latest sequence number for the specified partition
-   */
-  def latestSeqNo(partition: PartitionId): SequenceNumber
-
-  /**
-   * Provides the earliest and the latest sequence numbers in the provided
-   * partition.
-   *
-   * @param partition the partition that will be queried
-   * @return the earliest and latest sequence numbers for the specified partition.
-   */
-  def boundedSeqNos(partition: PartitionId): (SequenceNumber, SequenceNumber)
-
-  /**
-   * Similar to [[boundedSeqNos()]] except the information is collected for all
-   * partitions.
-   *
-   * @param partitionCount the number of partitions in the Event Hub instance
    * @return the earliest and latest sequence numbers for all partitions in the Event Hub
    */
-  def allBoundedSeqNos(partitionCount: Int): Seq[(PartitionId, (SequenceNumber, SequenceNumber))]
+  def allBoundedSeqNos: Seq[(PartitionId, (SequenceNumber, SequenceNumber))]
 
   /**
    * Translates all [[EventPosition]]s provided in the [[EventHubsConf]] to

--- a/core/src/main/scala/org/apache/spark/eventhubs/utils/RetryUtils.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/utils/RetryUtils.scala
@@ -102,28 +102,4 @@ private[spark] object RetryUtils extends Logging {
     }
     retryHelper(fn, 0)
   }
-
-  /**
-   * Retries synchronous calls for a fixed number of attempts.
-   *
-   * Only retries if the exception thrown on failure is an
-   * [[EventHubException]] where isTransient is marked as true.
-   *
-   * @param n the number of retries that will be performed.
-   * @param method the method name. This is to help with logging.
-   * @param fn the operation to be retried
-   * @tparam T the result type of the passed operation
-   * @return the result of the passed operation
-   */
-  @annotation.tailrec
-  final def retry[T](n: Int)(method: String)(fn: => T): T = {
-    logInfo(s"retry: $method: attempts left: $n")
-    Try { fn } match {
-      case Success(x) => x
-      case Failure(e: EventHubException) if e.getIsTransient && n > 1 =>
-        logInfo(s"retry: $method failure.", e)
-        retry(n - 1)(method)(fn)
-      case Failure(e) => throw e
-    }
-  }
 }

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubsDirectDStream.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubsDirectDStream.scala
@@ -82,13 +82,10 @@ private[spark] class EventHubsDirectDStream private[spark] (
   }
 
   protected def latestSeqNos(): Map[PartitionId, SequenceNumber] = {
-    ehClient
-      .allBoundedSeqNos(partitionCount)
-      .map {
-        case (p, (_, l)) =>
-          (p, l)
-      }
-      .toMap
+    ehClient.allBoundedSeqNos.map {
+      case (p, (_, l)) =>
+        (p, l)
+    }.toMap
   }
 
   protected def clamp(

--- a/core/src/test/scala/org/apache/spark/eventhubs/utils/EventHubsTestUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubs/utils/EventHubsTestUtilsSuite.scala
@@ -133,54 +133,6 @@ class EventHubsTestUtilsSuite
     assert(event.getSystemProperties.getSequenceNumber === 20)
   }
 
-  test("latestSeqNo") {
-    val eventHub = testUtils.createEventHubs(newEventHubs(), DefaultPartitionCount)
-
-    eventHub.send(Some(0), Seq(1), None)
-    eventHub.send(Some(1), Seq(2, 3), None)
-    eventHub.send(Some(2), Seq(4, 5, 6), None)
-    eventHub.send(Some(3), Seq(7), None)
-
-    val conf = testUtils.getEventHubsConf(eventHub.name)
-    val client = SimulatedClient(conf)
-    assert(client.latestSeqNo(0) == 1)
-    assert(client.latestSeqNo(1) == 2)
-    assert(client.latestSeqNo(2) == 3)
-    assert(client.latestSeqNo(3) == 1)
-  }
-
-  test("earliestSeqNo") {
-    val eventHub = testUtils.createEventHubs(newEventHubs(), DefaultPartitionCount)
-
-    eventHub.send(Some(0), Seq(1), None)
-    eventHub.send(Some(1), Seq(2, 3), None)
-    eventHub.send(Some(2), Seq(4, 5, 6), None)
-    eventHub.send(Some(3), Seq(7), None)
-
-    val conf = testUtils.getEventHubsConf(eventHub.name)
-    val client = SimulatedClient(conf)
-    assert(client.earliestSeqNo(0) == 0)
-    assert(client.earliestSeqNo(1) == 0)
-    assert(client.earliestSeqNo(2) == 0)
-    assert(client.earliestSeqNo(3) == 0)
-  }
-
-  test("boundedSeqNo") {
-    val eventHub = testUtils.createEventHubs(newEventHubs(), DefaultPartitionCount)
-
-    eventHub.send(Some(0), Seq(1), None)
-    eventHub.send(Some(1), Seq(2, 3), None)
-    eventHub.send(Some(2), Seq(4, 5, 6), None)
-    eventHub.send(Some(3), Seq(7), None)
-
-    val conf = testUtils.getEventHubsConf(eventHub.name)
-    val client = SimulatedClient(conf)
-    assert(client.boundedSeqNos(0) == (0, 1))
-    assert(client.boundedSeqNos(1) == (0, 2))
-    assert(client.boundedSeqNos(2) == (0, 3))
-    assert(client.boundedSeqNos(3) == (0, 1))
-  }
-
   test("allBoundedSeqNo") {
     val eventHub = testUtils.createEventHubs(newEventHubs(), DefaultPartitionCount)
 
@@ -191,7 +143,7 @@ class EventHubsTestUtilsSuite
 
     val conf = testUtils.getEventHubsConf(eventHub.name)
     val client = SimulatedClient(conf)
-    val results = client.allBoundedSeqNos(eventHub.partitionCount).toMap
+    val results = client.allBoundedSeqNos.toMap
     assert(results(0) == (0, 1))
     assert(results(1) == (0, 2))
     assert(results(2) == (0, 3))


### PR DESCRIPTION
In this PR we:

- Unify the retry policy in the connector. Most of the retry work is done in the Java client. If the connector receives a retryable exception from the Java client, it will retry it three times before passing the failure on to the user. 
- Add retry to epoch receiver creation in translate
- Remove sync methods that are no longer in use 