### PR TITLE
In translate, redo receive when it returns null

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubs/EventHubsConf.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/EventHubsConf.scala
@@ -352,7 +352,7 @@ final class EventHubsConf private (private val connectionStr: String)
   }
 
   /**
-   * Set the operation timeout. We will retry failures when contacting the
+   * Set the operation timeout. We will retryJava failures when contacting the
    * EventHubs service for the length of this timeout.
    * Default: [[DefaultOperationTimeout]]
    *

--- a/core/src/main/scala/org/apache/spark/eventhubs/client/CachedEventHubsReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/client/CachedEventHubsReceiver.scala
@@ -147,6 +147,7 @@ private[spark] object CachedEventHubsReceiver extends CachedReceiver with Loggin
                                           nAndP: NameAndPartition,
                                           requestSeqNo: SequenceNumber,
                                           batchSize: Int): EventData = {
+    logInfo(s"EventHubsCachedReceiver look up. For ${key(ehConf, nAndP)}")
     var receiver: CachedEventHubsReceiver = null
     receivers.synchronized {
       receiver = receivers.getOrElseUpdate(key(ehConf, nAndP), {

--- a/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsForeachWriter.scala
+++ b/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsForeachWriter.scala
@@ -47,7 +47,7 @@ case class EventHubsForeachWriter(ehConf: EventHubsConf) extends ForeachWriter[S
 
   def process(body: String): Unit = {
     val event = EventData.create(s"$body".getBytes("UTF-8"))
-    retry(client.send(event), "ForeachWriter")
+    retryJava(client.send(event), "ForeachWriter")
   }
 
   def close(errorOrNull: Throwable): Unit = {


### PR DESCRIPTION
This fixes a bug in the `translate` method. Previously, when we called `receive`, we could return null which led to a `NullPointerException`. Now, the receive call guarantees we get an `EventData` before continuing. We keep this operation on the Scala Execution Context. 

close #357 