### PR TITLE
Handle DescribedType in properties

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsRelation.scala
@@ -22,6 +22,7 @@ import org.apache.qpid.proton.amqp.{
   Decimal128,
   Decimal32,
   Decimal64,
+  DescribedType,
   Symbol,
   UnsignedByte,
   UnsignedInteger,
@@ -111,6 +112,7 @@ private[eventhubs] class EventHubsRelation(override val sqlContext: SQLContext,
                     case ul: UnsignedLong    => ul.toString.asInstanceOf[AnyRef]
                     case us: UnsignedShort   => us.toString.asInstanceOf[AnyRef]
                     case c: Character        => c.toString.asInstanceOf[AnyRef]
+                    case d: DescribedType    => d.getDescribed
                     case default             => default
                   }
                   .map { p =>

--- a/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsSource.scala
@@ -26,6 +26,7 @@ import org.apache.qpid.proton.amqp.{
   Decimal128,
   Decimal32,
   Decimal64,
+  DescribedType,
   Symbol,
   UnsignedByte,
   UnsignedInteger,
@@ -33,7 +34,6 @@ import org.apache.qpid.proton.amqp.{
   UnsignedShort
 }
 import org.apache.spark.SparkContext
-import org.apache.spark.eventhubs.client.Client
 import org.apache.spark.eventhubs.rdd.{ EventHubsRDD, OffsetRange }
 import org.apache.spark.eventhubs.{ EventHubsConf, NameAndPartition, _ }
 import org.apache.spark.internal.Logging
@@ -89,7 +89,7 @@ private[spark] class EventHubsSource private[eventhubs] (sqlContext: SQLContext,
   import EventHubsConf._
   import EventHubsSource._
 
-  private lazy val ehClient =  EventHubsSourceProvider.clientFactory(parameters)(ehConf)
+  private lazy val ehClient = EventHubsSourceProvider.clientFactory(parameters)(ehConf)
   private lazy val partitionCount: Int = ehClient.partitionCount
 
   private val ehConf = EventHubsConf.toConf(parameters)
@@ -99,7 +99,6 @@ private[spark] class EventHubsSource private[eventhubs] (sqlContext: SQLContext,
 
   private val maxOffsetsPerTrigger: Option[Long] =
     Option(parameters.get(MaxEventsPerTriggerKey).map(_.toLong).getOrElse(partitionCount * 1000))
-
 
   private lazy val initialPartitionSeqNos = {
     val metadataLog =
@@ -330,6 +329,7 @@ private[spark] class EventHubsSource private[eventhubs] (sqlContext: SQLContext,
                     case ul: UnsignedLong    => ul.toString.asInstanceOf[AnyRef]
                     case us: UnsignedShort   => us.toString.asInstanceOf[AnyRef]
                     case c: Character        => c.toString.asInstanceOf[AnyRef]
+                    case d: DescribedType    => d.getDescribed
                     case default             => default
                   }
                   .map { p =>

--- a/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsRelationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsRelationSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.eventhubs
 
-import java.nio.ByteBuffer
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.apache.qpid.proton.amqp._
@@ -121,7 +120,8 @@ class EventHubsRelationSuite extends QueryTest with BeforeAndAfter with SharedSQ
         "M" -> new Decimal64(13),
         "N" -> new UnsignedByte(1.toByte),
         "O" -> new UnsignedLong(987654321L),
-        "P" -> new UnsignedShort(Short.box(1))
+        "P" -> new UnsignedShort(Short.box(1)),
+        "Q" -> new UnknownDescribedType("descriptor", "described")
       ))
 
     // The expected serializes to:
@@ -144,6 +144,7 @@ class EventHubsRelationSuite extends QueryTest with BeforeAndAfter with SharedSQ
         case ul: UnsignedLong    => ul.toString.asInstanceOf[AnyRef]
         case us: UnsignedShort   => us.toString.asInstanceOf[AnyRef]
         case c: Character        => c.toString.asInstanceOf[AnyRef]
+        case d: DescribedType    => d.getDescribed
         case default             => default
       }
       .map { p =>

--- a/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsSourceSuite.scala
@@ -26,7 +26,9 @@ import org.apache.qpid.proton.amqp.{
   Decimal128,
   Decimal32,
   Decimal64,
+  DescribedType,
   Symbol,
+  UnknownDescribedType,
   UnsignedByte,
   UnsignedInteger,
   UnsignedLong,
@@ -509,7 +511,8 @@ class EventHubsSourceSuite extends EventHubsSourceTest {
         "M" -> new Decimal64(13),
         "N" -> new UnsignedByte(1.toByte),
         "O" -> new UnsignedLong(987654321L),
-        "P" -> new UnsignedShort(Short.box(1))
+        "P" -> new UnsignedShort(Short.box(1)),
+        "Q" -> new UnknownDescribedType("descriptor", "described")
       ))
 
     // The expected serializes to:
@@ -532,6 +535,7 @@ class EventHubsSourceSuite extends EventHubsSourceTest {
         case ul: UnsignedLong    => ul.toString.asInstanceOf[AnyRef]
         case us: UnsignedShort   => us.toString.asInstanceOf[AnyRef]
         case c: Character        => c.toString.asInstanceOf[AnyRef]
+        case d: DescribedType    => d.getDescribed
         case default             => default
       }
       .map { p =>


### PR DESCRIPTION
close #372 

When we convert proton-j primitives to strings, `DescribedType` was overlooked. This handles the `DescribedType` case as well. 