### PR TITLE
Properties can be added in EventHubsSink

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubs/client/Client.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/client/Client.scala
@@ -51,7 +51,8 @@ private[spark] trait Client extends Serializable {
    */
   def send(event: EventData,
            partition: Option[Int] = None,
-           partitionKey: Option[String] = None): Unit
+           partitionKey: Option[String] = None,
+           properties: Option[Map[String, String]] = None): Unit
 
   /**
    * Returns the earliest and latest sequence numbers for all partitions

--- a/core/src/main/scala/org/apache/spark/eventhubs/utils/SimulatedClient.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/utils/SimulatedClient.scala
@@ -58,11 +58,12 @@ private[spark] class SimulatedClient(private val ehConf: EventHubsConf) extends 
    */
   override def send(event: EventData,
                     partition: Option[Int] = None,
-                    partitionKey: Option[String] = None): Unit = {
+                    partitionKey: Option[String] = None,
+                    properties: Option[Map[String, String]]): Unit = {
     if (partitionKey.isDefined) {
       throw new UnsupportedOperationException
     } else {
-      eventHub.send(partition, event)
+      eventHub.send(partition, event, properties)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/eventhubs/utils/SimulatedEventHubs.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/utils/SimulatedEventHubs.scala
@@ -108,14 +108,16 @@ private[spark] class SimulatedEventHubs(val name: String, val partitionCount: In
    * @param partition the partition to send events to
    * @param event the event being sent
    */
-  private[utils] def send(partition: Option[PartitionId], event: EventData): Unit = {
+  private[utils] def send(partition: Option[PartitionId],
+                          event: EventData,
+                          properties: Option[Map[String, Object]]): Unit = {
     if (partition.isDefined) {
-      synchronized(partitions(partition.get).send(event))
+      synchronized(partitions(partition.get).send(event, properties))
     } else {
       synchronized {
         val part = count % this.partitionCount
         count += 1
-        this.send(Some(part), event)
+        this.send(Some(part), event, properties)
       }
     }
   }
@@ -202,9 +204,9 @@ private[spark] class SimulatedEventHubs(val name: String, val partitionCount: In
      *
      * @param event event being sent
      */
-    private[utils] def send(event: EventData): Unit = {
+    private[utils] def send(event: EventData, properties: Option[Map[String, Object]]): Unit = {
       // Need to add a Seq No to the EventData to properly simulate the service.
-      val e = EventHubsTestUtils.createEventData(event.getBytes, data.size.toLong, None)
+      val e = EventHubsTestUtils.createEventData(event.getBytes, data.size.toLong, properties)
       synchronized(data = data :+ e)
     }
 

--- a/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsSink.scala
+++ b/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsSink.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.eventhubs
 
-import org.apache.spark.eventhubs.EventHubsConf
-import org.apache.spark.eventhubs.client.Client
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{ DataFrame, SQLContext }
 import org.apache.spark.sql.execution.streaming.Sink

--- a/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsWriter.scala
+++ b/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsWriter.scala
@@ -41,6 +41,7 @@ private[eventhubs] object EventHubsWriter extends Logging {
   val BodyAttributeName = "body"
   val PartitionKeyAttributeName = "partitionKey"
   val PartitionIdAttributeName = "partition"
+  val PropertiesAttributeName = "properties"
 
   override def toString: String = "EventHubsWriter"
 

--- a/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsSinkSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsSinkSuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.streaming._
 import org.apache.spark.sql.test.SharedSQLContext
 import org.scalatest.time.Span
+import collection.JavaConverters._
 
 class EventHubsSinkSuite extends StreamTest with SharedSQLContext {
   import testImplicits._
@@ -68,10 +69,14 @@ class EventHubsSinkSuite extends StreamTest with SharedSQLContext {
   private def createEventHubsWriter(
       input: DataFrame,
       ehConf: EventHubsConf,
-      withOutputMode: Option[OutputMode] = None)(withSelectExrp: String*): StreamingQuery = {
+      withOutputMode: Option[OutputMode] = None,
+      properties: Option[Map[String, String]] = None)(withSelectExrp: String*): StreamingQuery = {
     var stream: DataStreamWriter[Row] = null
     withTempDir { checkpointDir =>
       var df = input.toDF().withColumnRenamed("value", "body")
+      if (properties.isDefined) {
+        df = df.withColumn("properties", typedLit(properties.get))
+      }
       if (withSelectExrp.nonEmpty) {
         df = df.selectExpr(withSelectExrp: _*)
       }
@@ -224,6 +229,89 @@ class EventHubsSinkSuite extends StreamTest with SharedSQLContext {
       }
       assert(testUtils.getEventHubs(eh).getPartitions(targetPart.toPartitionId).size == 9)
       checkDatasetUnorderly(reader(ehConf), 1, 2, 2, 3, 3, 3, 1, 2, 3)
+    } finally {
+      writer.stop()
+    }
+  }
+
+  test("streaming - write with properties and partition") {
+    val targetPart = "0"
+    val targetProperties = Map("a" -> "3", "b" -> "bar", "c" -> "spark")
+    val input = MemoryStream[String]
+    val eh = newEventHub()
+    testUtils.createEventHubs(eh, partitionCount = 10)
+    val ehConf = getEventHubsConf(eh)
+
+    val writer = createEventHubsWriter(
+      input.toDF,
+      ehConf,
+      withOutputMode = Some(OutputMode.Update()),
+      properties = Some(targetProperties)
+    )("properties", "body", s"'$targetPart' as partition")
+
+    val reader = (e: EventHubsConf) => createReader(e).as[String].map(_.toInt)
+
+    try {
+      input.addData("1", "2", "2", "3", "3", "3")
+      failAfter(streamingTimeout) {
+        writer.processAllAvailable()
+      }
+      assert(testUtils.getEventHubs(eh).getPartitions(targetPart.toPartitionId).size == 6)
+      checkDatasetUnorderly(reader(ehConf), 1, 2, 2, 3, 3, 3)
+      input.addData("1", "2", "3")
+      failAfter(streamingTimeout) {
+        writer.processAllAvailable()
+      }
+      assert(testUtils.getEventHubs(eh).getPartitions(targetPart.toPartitionId).size == 9)
+      checkDatasetUnorderly(reader(ehConf), 1, 2, 2, 3, 3, 3, 1, 2, 3)
+      assert(
+        testUtils
+          .getEventHubs(eh)
+          .getPartitions(targetPart.toPartitionId)
+          .getEvents
+          .head
+          .getProperties
+          .asScala == targetProperties)
+    } finally {
+      writer.stop()
+    }
+  }
+
+  test("streaming - write with properties") {
+    val targetProperties = Map("property" -> "foo", "another" -> "bar")
+    val input = MemoryStream[String]
+    val eh = newEventHub()
+    testUtils.createEventHubs(eh, partitionCount = 10)
+    val ehConf = getEventHubsConf(eh)
+
+    val writer = createEventHubsWriter(
+      input.toDF,
+      ehConf,
+      withOutputMode = Some(OutputMode.Update()),
+      properties = Some(targetProperties)
+    )("properties", "body")
+
+    val reader = (e: EventHubsConf) => createReader(e).as[String].map(_.toInt)
+
+    try {
+      input.addData("1", "2", "2", "3", "3", "3")
+      failAfter(streamingTimeout) {
+        writer.processAllAvailable()
+      }
+      checkDatasetUnorderly(reader(ehConf), 1, 2, 2, 3, 3, 3)
+      input.addData("1", "2", "3")
+      failAfter(streamingTimeout) {
+        writer.processAllAvailable()
+      }
+      checkDatasetUnorderly(reader(ehConf), 1, 2, 2, 3, 3, 3, 1, 2, 3)
+      assert(
+        testUtils
+          .getEventHubs(eh)
+          .getPartitions(0)
+          .getEvents
+          .head
+          .getProperties
+          .asScala == targetProperties)
     } finally {
       writer.stop()
     }

--- a/docs/structured-streaming-eventhubs-integration.md
+++ b/docs/structured-streaming-eventhubs-integration.md
@@ -280,6 +280,7 @@ The Dataframe being written to EventHubs should have the following columns in th
 | body (required) | string or binary |
 | partitionId (*optional) | string |
 | partitionKey (*optional) | string |
+| properties (optional) | map[string, string] |
 
 * Only one (partitionId or partitionKey) can be set at a time. If both are set, your Structured Streaming job will be stopped. 
 
@@ -288,6 +289,8 @@ using a round-robin model. Alternatively, if a partitionId is provided, the quer
 Sending to a single partition is *not* a recommended pattern. Finally, if a partionKey is provided, each event will be sent with the
 provided partitionKey. For more information on how a partitionKey works, click 
 [here](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-programming-guide#partition-key).
+
+Users can also provided properties via a `map[string, string]` if they would like to send any additional properties with their events. 
 
 ### Creating an EventHubs Sink for Streaming Queries 
 


### PR DESCRIPTION
This allows properties to be added to events before they're written to Event Hubs. The properties must be contained in a column named `properties` and it must be of type `Map[String, String]`. 

close #370 