### PR TITLE
Cached receivers are async

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,5 +1,26 @@
 # Azure Event Hubs Connector for Apache Spark FAQ
 
+If anything is unclear or if you have feedback, comments, or questions of any kind, then please let us know!
+We're available on the [gitter chat](https://gitter.im/azure-event-hubs-spark/Lobby). 
+
+**Why am I seeing: `"The expected sequence number xxx is less than the received sequence number yyy."?`**
+
+Your Event Hubs has a retention policy of 1 to 7 days. Once an event has been in your Event Hubs for 
+the length of your retention policy, it will be removed by the service -- I say that the event *expires*. 
+
+In Spark, we schedule a range of events that will be included in the next batch. Let's say we schedule to consume 
+from sequence number `X` to `Y` on partition `1`. Then, the Spark executor will try to receive from sequence 
+number `X`. There's a case where sequence number `X` is present in the Event Hubs **when we schedule** but 
+it expires **before we consume it**. In that case, we'll see the above error message! 
+
+Now that you understand the message, what should we do about it? Well, this happens when your stream is really
+behind. Ideally, we want the throughput in Spark to be high enough so that we're always near the latest events. 
+Having said that, the best way to handle this error message is to increase your throughput in Spark, increase 
+your retention policy in Event Hubs, or both. 
+
+It's also worth noting that you may see this more often in testing scenarios due to irregular send patterns. 
+If that's the case, simply send fresh events to the Event Hubs and continue testing with those. 
+
 **Why am I getting a `ReceiverDisconnectedException`?**
 
 In version 2.3.2 and above, the connector uses epoch receivers from the Event Hubs Java client. 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ By making Event Hubs and Spark easier to use together, we hope this connector ma
 
 #### Roadmap
 
-There is an open issue for each planned feature/enhancement. Additional comments can be found on 
-our [wiki](https://github.com/Azure/azure-event-hubs-spark/wiki).
+There is an open issue for each planned feature/enhancement. 
 
 ## Usage
 
@@ -64,6 +63,11 @@ Documentation for our connector can be found [here](docs/). The integration guid
 documentation [here](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-what-is-event-hubs), documentation for Spark Streaming 
 [here](https://spark.apache.org/docs/latest/streaming-programming-guide.html), and, the last but not least, Structured Streaming 
 [here](https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html). 
+
+### FAQ
+
+We maintain an [FAQ](FAQ.md) - reach out to us via [gitter](https://gitter.im/azure-event-hubs-spark/Lobby) 
+if you think anything needs to be added or clarified!
 
 ### Further Assistance 
 

--- a/core/src/main/scala/org/apache/spark/eventhubs/client/CachedEventHubsReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/client/CachedEventHubsReceiver.scala
@@ -18,17 +18,21 @@
 package org.apache.spark.eventhubs.client
 
 import com.microsoft.azure.eventhubs._
+import org.apache.spark.eventhubs.utils.RetryUtils.{ retryJava, retryNotNull }
 import org.apache.spark.{ SparkEnv, TaskContext }
 import org.apache.spark.eventhubs.{ EventHubsConf, NameAndPartition, SequenceNumber }
 import org.apache.spark.internal.Logging
 
-import scala.util.{ Failure, Success, Try }
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.collection.JavaConverters._
+import scala.util.Success
 
 private[spark] trait CachedReceiver {
   private[eventhubs] def receive(ehConf: EventHubsConf,
                                  nAndP: NameAndPartition,
                                  requestSeqNo: SequenceNumber,
-                                 batchSize: Int): EventData
+                                 batchSize: Int): Iterator[EventData]
 }
 
 /**
@@ -48,83 +52,94 @@ private[spark] trait CachedReceiver {
  * @param nAndP the Event Hub name and partition that the receiver is connected to.
  */
 private[client] class CachedEventHubsReceiver private (ehConf: EventHubsConf,
-                                                       nAndP: NameAndPartition)
+                                                       nAndP: NameAndPartition,
+                                                       startSeqNo: SequenceNumber)
     extends Logging {
 
   import org.apache.spark.eventhubs._
 
   private lazy val client: EventHubClient = ClientConnectionPool.borrowClient(ehConf)
 
+  private var _receiver: Future[PartitionReceiver] = _
+  private def receiver: Future[PartitionReceiver] = {
+    if (_receiver == null) {
+      throw new IllegalStateException(s"No receiver for $nAndP")
+    }
+    _receiver
+  }
+  createReceiver(startSeqNo)
+
   private def createReceiver(requestSeqNo: SequenceNumber): Unit = {
+    assert(_receiver == null)
     logInfo(s"creating receiver for Event Hub ${nAndP.ehName} on partition ${nAndP.partitionId}")
     val consumerGroup = ehConf.consumerGroup.getOrElse(DefaultConsumerGroup)
     val receiverOptions = new ReceiverOptions
     receiverOptions.setReceiverRuntimeMetricEnabled(false)
     receiverOptions.setIdentifier(
       s"spark-${SparkEnv.get.executorId}-${TaskContext.get.taskAttemptId}")
-    _receiver = client.createEpochReceiverSync(
-      consumerGroup,
-      nAndP.partitionId.toString,
-      EventPosition.fromSequenceNumber(requestSeqNo).convert,
-      DefaultEpoch,
-      receiverOptions)
-    _receiver.setPrefetchCount(DefaultPrefetchCount)
+    _receiver = retryJava(
+      client.createEpochReceiver(consumerGroup,
+                                 nAndP.partitionId.toString,
+                                 EventPosition.fromSequenceNumber(requestSeqNo).convert,
+                                 DefaultEpoch,
+                                 receiverOptions),
+      "CachedReceiver creation."
+    )
+    _receiver.onComplete {
+      case Success(r) => r.setPrefetchCount(DefaultPrefetchCount)
+      case _          =>
+    }
   }
 
   private def closeReceiver(): Unit = {
-    Try(_receiver.closeSync()) match {
-      case Success(_) => _receiver = null
-      case Failure(e) =>
-        logInfo("closeSync failed in cached receiver.", e)
-        _receiver = null
-    }
+    val r = Await.result(receiver, InternalOperationTimeout)
+    _receiver = null
+    retryJava(r.close(), "CachedReceiver close.")
   }
 
-  private var _receiver: PartitionReceiver = _
-  private def receiver: PartitionReceiver = {
-    if (_receiver == null) {
-      throw new IllegalStateException(s"No receiver for $nAndP")
-    }
-    _receiver
-  }
-
-  private def errWrongSeqNo(requestSeqNo: SequenceNumber, receivedSeqNo: SequenceNumber): String =
-    s"requestSeqNo $requestSeqNo does not match the received sequence number $receivedSeqNo"
-
-  private def receive(requestSeqNo: SequenceNumber, batchSize: Int): EventData = {
-    def receiveOneEvent: EventData = {
-      var event: EventData = null
-      var i: java.lang.Iterable[EventData] = null
-      while (i == null) {
-        i = try {
-          receiver.receiveSync(1)
-        } catch {
-          case r: ReceiverDisconnectedException =>
-            throw new Exception(
-              "You are likely running multiple Spark jobs with the same consumer group. " +
-                "For each Spark job, please create and use a unique consumer group to avoid this issue.",
-              r
-            )
-        }
+  private def receiveOne: Future[Iterable[EventData]] = {
+    receiver
+      .flatMap { r =>
+        retryNotNull(r.receive(1), "CachedReceiver receive call")
       }
-      event = i.iterator.next
-      event
-    }
+      .map { e =>
+        e.asScala
+      }
+  }
 
-    var event: EventData = receiveOneEvent
-    if (requestSeqNo != event.getSystemProperties.getSequenceNumber) {
+  private def checkCursor(requestSeqNo: SequenceNumber): Future[Iterable[EventData]] = {
+    val event = Await.result(receiveOne, InternalOperationTimeout)
+    if (requestSeqNo != event.head.getSystemProperties.getSequenceNumber) {
       logWarning(
-        s"$requestSeqNo did not match ${event.getSystemProperties.getSequenceNumber}." +
+        s"$requestSeqNo did not match ${event.head.getSystemProperties.getSequenceNumber}." +
           s"Recreating receiver for $nAndP")
       closeReceiver()
       createReceiver(requestSeqNo)
-      event = receiveOneEvent
-      assert(requestSeqNo == event.getSystemProperties.getSequenceNumber,
-             errWrongSeqNo(requestSeqNo, event.getSystemProperties.getSequenceNumber))
+      receiveOne
+    } else {
+      Future { event }
+    }
+  }
+
+  private def receive(requestSeqNo: SequenceNumber, batchSize: Int): Iterator[EventData] = {
+    val first = checkCursor(requestSeqNo)
+    val theRest = Future.sequence(for { _ <- 1 until batchSize } yield receiveOne)
+    val combined = for {
+      theRestRes <- theRest
+      firstRes <- first
+    } yield firstRes ++ theRestRes.flatten
+    val sorted = combined.map { data =>
+      data.toSeq
+        .sortWith((e1, e2) =>
+          e1.getSystemProperties.getSequenceNumber < e2.getSystemProperties.getSequenceNumber)
+        .iterator
     }
     val newPrefetchCount = if (batchSize < PrefetchCountMinimum) PrefetchCountMinimum else batchSize
-    receiver.setPrefetchCount(newPrefetchCount)
-    event
+    receiver.onComplete {
+      case Success(r) => r.setPrefetchCount(newPrefetchCount)
+      case _          =>
+    }
+    Await.result(sorted, InternalOperationTimeout)
   }
 }
 
@@ -146,7 +161,7 @@ private[spark] object CachedEventHubsReceiver extends CachedReceiver with Loggin
   private[eventhubs] override def receive(ehConf: EventHubsConf,
                                           nAndP: NameAndPartition,
                                           requestSeqNo: SequenceNumber,
-                                          batchSize: Int): EventData = {
+                                          batchSize: Int): Iterator[EventData] = {
     logInfo(s"EventHubsCachedReceiver look up. For ${key(ehConf, nAndP)}")
     var receiver: CachedEventHubsReceiver = null
     receivers.synchronized {
@@ -160,8 +175,6 @@ private[spark] object CachedEventHubsReceiver extends CachedReceiver with Loggin
   def apply(ehConf: EventHubsConf,
             nAndP: NameAndPartition,
             startSeqNo: SequenceNumber): CachedEventHubsReceiver = {
-    val cr = new CachedEventHubsReceiver(ehConf, nAndP)
-    cr.createReceiver(startSeqNo)
-    cr
+    new CachedEventHubsReceiver(ehConf, nAndP, startSeqNo)
   }
 }

--- a/core/src/main/scala/org/apache/spark/eventhubs/utils/SimulatedCachedReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/utils/SimulatedCachedReceiver.scala
@@ -21,6 +21,8 @@ import com.microsoft.azure.eventhubs.EventData
 import org.apache.spark.eventhubs.{ EventHubsConf, NameAndPartition, SequenceNumber }
 import org.apache.spark.eventhubs.client.CachedReceiver
 
+import scala.collection.JavaConverters._
+
 /**
  * Simulated version of the cached receivers.
  */
@@ -40,7 +42,7 @@ private[spark] object SimulatedCachedReceiver extends CachedReceiver {
   override def receive(ehConf: EventHubsConf,
                        nAndP: NameAndPartition,
                        requestSeqNo: SequenceNumber,
-                       batchSize: Int): EventData = {
-    eventHubs(ehConf.name).receive(1, nAndP.partitionId, requestSeqNo).iterator().next()
+                       batchSize: Int): Iterator[EventData] = {
+    eventHubs(ehConf.name).receive(batchSize, nAndP.partitionId, requestSeqNo).iterator.asScala
   }
 }

--- a/core/src/main/scala/org/apache/spark/eventhubs/utils/SimulatedEventHubs.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/utils/SimulatedEventHubs.scala
@@ -70,7 +70,7 @@ private[spark] class SimulatedEventHubs(val name: String, val partitionCount: In
   def receive(eventCount: Int,
               partition: Int,
               seqNo: SequenceNumber): java.lang.Iterable[EventData] = {
-    (for { _ <- 0 until eventCount } yield partitions(partition).get(seqNo)).asJava
+    (for { i <- 0 until eventCount } yield partitions(partition).get(seqNo + i)).asJava
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/eventhubs/utils/EventHubsTestUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubs/utils/EventHubsTestUtilsSuite.scala
@@ -127,10 +127,9 @@ class EventHubsTestUtilsSuite
       }
     }
     val conf = testUtils.getEventHubsConf(eventHub.name)
-    // batchSize is just a dummy value.
     val event =
-      SimulatedCachedReceiver.receive(conf, NameAndPartition(conf.name, 0), 20, batchSize = 0)
-    assert(event.getSystemProperties.getSequenceNumber === 20)
+      SimulatedCachedReceiver.receive(conf, NameAndPartition(conf.name, 0), 20, batchSize = 1)
+    assert(event.next.getSystemProperties.getSequenceNumber === 20)
   }
 
   test("allBoundedSeqNo") {


### PR DESCRIPTION
This re-works cached receivers. All receivers and receive calls are done asynchronously. All receive calls are retried as well and they're retried until a non-null event is returned. 

When we hand off the events to Spark, we make sure the data is in order by sequence number. 

#363 #367