### PR TITLE
Redo check cursor

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-eventhubs-spark-parent_2.11</artifactId>
-    <version>2.3.3</version>
+    <version>2.3.4-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>azure-eventhubs-spark_2.11</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>com.microsoft.azure</groupId>
   <artifactId>azure-eventhubs-spark-parent_2.11</artifactId>
-  <version>2.3.3</version>
+  <version>2.3.4-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>EventHubs+Spark Parent POM</name>


### PR DESCRIPTION
Redoing check cursor - now we recreate the receiver to ensure there's a data loss issue going on when we fail the jobs (instead of just failing the jobs whenever there's a mismatch in sequence numbers). 