### PR TITLE
Receive calls one at a time to avoid overloading thread pool

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-eventhubs-spark-parent_2.11</artifactId>
-    <version>2.3.4</version>
+    <version>2.3.5-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>azure-eventhubs-spark_2.11</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>com.microsoft.azure</groupId>
   <artifactId>azure-eventhubs-spark-parent_2.11</artifactId>
-  <version>2.3.4</version>
+  <version>2.3.5-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>EventHubs+Spark Parent POM</name>


### PR DESCRIPTION
In this PR:
* `receiveOne` is called one at a time. Specifically, we only issue one async receive call at a time, and we don't issue the *next* receive call until the *previous* is completed. This should remove load from the underlying client thread pool for large batches, and, therefore, ensure fairer use of resources across the cluster.
* `receiveOne` now accepts a specialized message to improve tracing. All receive calls have a specific message so we can identify failures more easily. 