### PR TITLE
[WIP] Issues with seqNo and Eventhub Retention

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubs/utils/EventHubsTestUtils.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/utils/EventHubsTestUtils.scala
@@ -20,19 +20,13 @@ package org.apache.spark.eventhubs.utils
 import java.util.Date
 
 import com.microsoft.azure.eventhubs.EventData
-import com.microsoft.azure.eventhubs.impl.AmqpConstants.{
-  ENQUEUED_TIME_UTC,
-  OFFSET,
-  SEQUENCE_NUMBER
-}
+import com.microsoft.azure.eventhubs.impl.AmqpConstants.{ENQUEUED_TIME_UTC, OFFSET, SEQUENCE_NUMBER}
 import com.microsoft.azure.eventhubs.impl.EventDataImpl
 import org.apache.qpid.proton.amqp.Binary
-import org.apache.qpid.proton.amqp.messaging.{ ApplicationProperties, Data, MessageAnnotations }
+import org.apache.qpid.proton.amqp.messaging.{ApplicationProperties, Data, MessageAnnotations}
 import org.apache.qpid.proton.message.Message
 import org.apache.qpid.proton.message.Message.Factory
-import org.apache.spark.eventhubs.{ EventHubsConf, NameAndPartition }
-import org.apache.spark.eventhubs.client.{ CachedReceiver, Client }
-import org.apache.spark.eventhubs._
+import org.apache.spark.eventhubs.{EventHubsConf, NameAndPartition, _}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -54,19 +48,34 @@ private[spark] class EventHubsTestUtils {
   import EventHubsTestUtils._
 
   /**
-   * Sends events to the specified simulated event hub.
-   *
-   * @param ehName the event hub to send to
-   * @param partition the partition id that will receive the data
-   * @param data the data being sent
-   * @param properties additional application properties
-   * @return
-   */
+    * Sends events to the specified simulated event hub.
+    *
+    * @param ehName the event hub to send to
+    * @param partition the partition id that will receive the data
+    * @param data the data being sent
+    * @param properties additional application properties
+    * @return
+    */
   def send(ehName: String,
            partition: Option[PartitionId] = None,
            data: Seq[Int],
            properties: Option[Map[String, Object]] = None): Seq[Int] = {
     eventHubs(ehName).send(partition, data, properties)
+  }
+
+  /**
+    * Sends events to the specified simulated event hub.
+    *
+    * @param ehName the event hub to send to
+    * @param partition the partition id that will receive the data
+    * @param data the data being sent
+    * @return
+    */
+  def send(ehName: String,
+           partition: PartitionId,
+           data: Seq[EventData]): Unit = {
+    val eh = eventHubs(ehName)
+    data.foreach(event => eh.send(partition, event))
   }
 
   /**
@@ -197,7 +206,7 @@ private[spark] object EventHubsTestUtils {
     constructor.setAccessible(true)
 
     val s = seqNo.toLong.asInstanceOf[AnyRef]
-    // This value is not accurate. However, "offet" is never used in testing.
+    // This value is not accurate. However, "offset" is never used in testing.
     // Placing dummy value here because one is required in order for EventData
     // to serialize/de-serialize properly during tests.
     val o = s.toString.asInstanceOf[AnyRef]

--- a/core/src/main/scala/org/apache/spark/eventhubs/utils/SimulatedClient.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/utils/SimulatedClient.scala
@@ -102,9 +102,12 @@ private[spark] class SimulatedClient(private val ehConf: EventHubsConf) extends 
     } else {
       require(positions.get.forall(x => x._2.seqNo >= 0L))
       require(positions.get.size == partitionCount)
-      positions.get.map { case (k, v) => k.partitionId -> v }.mapValues(_.seqNo).mapValues {
-        seqNo =>
-          { if (seqNo == -1L) 0L else seqNo }
+      positions.get.map {
+        case (k, v) => k.partitionId -> v
+      }.mapValues(_.seqNo).mapValues {
+        seqNo => {
+          if (seqNo == -1L) 0L else seqNo
+        }
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsSourceTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsSourceTest.scala
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.eventhubs
+import org.apache.spark.eventhubs.EventHubsConf
+import org.apache.spark.eventhubs.utils.EventHubsTestUtils
+import org.apache.spark.sql.execution.streaming.{Offset, Source, StreamExecution, StreamingExecutionRelation}
+import org.apache.spark.sql.streaming.StreamTest
+import org.apache.spark.sql.test.SharedSQLContext
+import org.json4s.{Formats, NoTypeHints}
+import org.json4s.jackson.Serialization
+import org.scalatest.time.Span
+import org.scalatest.time.SpanSugar._
+
+abstract class EventHubsSourceTest extends StreamTest with SharedSQLContext {
+
+  protected var testUtils: EventHubsTestUtils = _
+
+  implicit val formats: AnyRef with Formats = Serialization.formats(NoTypeHints)
+
+  override def beforeAll: Unit = {
+    super.beforeAll
+    testUtils = new EventHubsTestUtils
+  }
+
+  override def afterAll(): Unit = {
+    if (testUtils != null) {
+      testUtils.destroyAllEventHubs()
+      testUtils = null
+    }
+    super.afterAll()
+  }
+
+  override val streamingTimeout: Span = 30.seconds
+
+  protected def makeSureGetOffsetCalled = AssertOnQuery { q =>
+    // Because EventHubsSource's initialPartitionOffsets is set lazily, we need to make sure
+    // its "getOffset" is called before pushing any data. Otherwise, because of the race condition,
+    // we don't know which data should be fetched when `startingOffsets` is latest.
+    q.processAllAvailable()
+    true
+  }
+
+  case class AddEventHubsData(conf: EventHubsConf, data: Int*)(implicit concurrent: Boolean = false,
+                                                               message: String = "")
+    extends AddData {
+
+    override def addData(query: Option[StreamExecution]): (Source, Offset) = {
+      if (query.get.isActive) {
+        query.get.processAllAvailable()
+      }
+
+      val sources = query.get.logicalPlan.collect {
+        case StreamingExecutionRelation(source, _) if source.isInstanceOf[EventHubsSource] =>
+          source.asInstanceOf[EventHubsSource]
+      }
+      if (sources.isEmpty) {
+        throw new Exception(
+          "Could not find EventHubs source in the StreamExecution logical plan to add data to")
+      } else if (sources.size > 1) {
+        throw new Exception(
+          "Could not select the EventHubs source in the StreamExecution logical plan as there" +
+            "are multiple EventHubs sources:\n\t" + sources.mkString("\n\t"))
+      }
+
+      val ehSource = sources.head
+      testUtils.send(conf.name, data = data)
+
+      val seqNos = testUtils.getLatestSeqNos(conf)
+      require(seqNos.size == testUtils.getEventHubs(conf.name).partitionCount)
+
+      val offset = EventHubsSourceOffset(seqNos)
+      logInfo(s"Added data, expected offset $offset")
+      (ehSource, offset)
+    }
+
+    override def toString: String = {
+      s"AddEventHubsData(data: $data)"
+    }
+  }
+}

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/EventHubsDirectDStreamSuite.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/EventHubsDirectDStreamSuite.scala
@@ -56,7 +56,7 @@ class EventHubsDirectDStreamSuite
 
   private var testUtils: EventHubsTestUtils = _
 
-  val sparkConf = new SparkConf().setMaster("local[4]").setAppName(this.getClass.getSimpleName)
+  val sparkConf: SparkConf = new SparkConf().setMaster("local[4]").setAppName(this.getClass.getSimpleName)
 
   private var ssc: StreamingContext = _
   private var testDir: File = _


### PR DESCRIPTION
It feels like we're having some issues with the retention of the Event Hub.
When starting a Spark job that reads from a consumer group that already has some pruned messages
because then run out of retention.

```
java.lang.IllegalStateException: In partition 1 of eventhubdev, with consumer group consumergroup-1,
request seqNo 1921738 is less than the received seqNo 1924294.
The earliest seqNo is 1924293 and the last seqNo is 1944993
```

First I need to fix another issue with the Simulator, which I'll do in another PR to keep everything nicely separated. Currently, the latest seqNo is implemented by taking the `size()` of the messages within a certain partition. This is not right, we want to take the max of the seqNo of the actual messages:
https://github.com/Azure/azure-event-hubs-spark/blob/61aba38334f0bf13a7c2bbee0fafd0b7653e687e/core/src/main/scala/org/apache/spark/eventhubs/utils/SimulatedEventHubs.scala#L252

Thanks for contributing! We appreciate it :) 

For a Pull Request to be accepted, you must:
- Run scalafmt on your code using the `.scalafmt.conf` present in this project
- All tests must pass when you run `mvn clean test` 

Just in case, here are some tips that could prove useful when opening a pull request:
- Read the [Contributor's Guide](CONTRIBUTING.md)
- Make the title of pull request is clear and informative. 
- There should be a small number of commits, all with informative messages. 
- The pull request shouldn't introduce any breaking changes (unless will occur on the next release) 
- Any public code should be properly documented 
- Be sure to write tests for any changes in the pull request
- The code should build without any errors 