### PR TITLE
Provide a knob to specify the size of thread pool and recreate the underlying receiver if operation times out

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubs/EventHubsConf.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/EventHubsConf.scala
@@ -164,6 +164,7 @@ final class EventHubsConf private (private val connectionStr: String)
       "eventhubs.receiverTimeout",
       "eventhubs.operationTimeout",
       "eventhubs.prefetchCount",
+      "eventhubs.threadPoolSize",
       "useSimulatedClient"
     ).map(_.toLowerCase).toSet
 
@@ -403,6 +404,22 @@ final class EventHubsConf private (private val connectionStr: String)
   }
 
   /**
+   * Set the size of thread pool.
+   * Default: [[DefaultThreadPoolSize]]
+   *
+   * @param size the size of thread pool
+   * @return the updated [[EventHubsConf]] instance
+   */
+  def setThreadPoolSize(size: Int): EventHubsConf = {
+    set(ThreadPoolSizeKey, size)
+  }
+
+  /** The current thread pool size.  */
+  def threadPoolSize: Option[Int] = {
+    self.get(ThreadPoolSizeKey) map (str => str.toInt)
+  }
+
+  /**
    * Rate limit on maximum number of events processed per trigger interval.
    * Only valid for Structured Streaming. The specified total number of events
    * will be proportionally split across partitions of different volume.
@@ -460,6 +477,7 @@ object EventHubsConf extends Logging {
   val ReceiverTimeoutKey = "eventhubs.receiverTimeout"
   val OperationTimeoutKey = "eventhubs.operationTimeout"
   val PrefetchCountKey = "eventhubs.prefetchCount"
+  val ThreadPoolSizeKey = "eventhubs.threadPoolSize"
   val MaxEventsPerTriggerKey = "maxEventsPerTrigger"
   val UseSimulatedClientKey = "useSimulatedClient"
 

--- a/core/src/test/scala/org/apache/spark/eventhubs/EventHubsConfSuite.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubs/EventHubsConfSuite.scala
@@ -219,6 +219,7 @@ class EventHubsConfSuite extends FunSuite with BeforeAndAfterAll {
       .setMaxEventsPerTrigger(100)
       .setReceiverTimeout(Duration.ofSeconds(10))
       .setOperationTimeout(Duration.ofSeconds(10))
+      .setThreadPoolSize(16)
       .setPrefetchCount(100)
 
     val newConf = originalConf.trimmed
@@ -235,6 +236,7 @@ class EventHubsConfSuite extends FunSuite with BeforeAndAfterAll {
     originalConf("eventhubs.receiverTimeout")
     originalConf("eventhubs.operationTimeout")
     originalConf("eventhubs.prefetchCount")
+    originalConf("eventhubs.threadPoolSize")
     originalConf("maxEventsPerTrigger")
     originalConf("useSimulatedClient")
 
@@ -250,6 +252,7 @@ class EventHubsConfSuite extends FunSuite with BeforeAndAfterAll {
     newConf("eventhubs.receiverTimeout")
     newConf("eventhubs.operationTimeout")
     newConf("eventhubs.prefetchCount")
+    newConf("eventhubs.threadPoolSize")
     intercept[NoSuchElementException] { newConf("maxEventsPerTrigger") }
     newConf("useSimulatedClient")
   }


### PR DESCRIPTION
In this PR we:
- Create a `ClientThreadPool` per connection string.
- Allow the client thread pool size to be configurable 
- Recreate receivers when operations time out