### PR TITLE
[In progress] Fix partition id not matching error if checkpoint is outdated

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubs/ConnectionStringBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/ConnectionStringBuilder.scala
@@ -240,6 +240,10 @@ class ConnectionStringBuilder private () {
     this
   }
 
+  def getNamespace: String = {
+    this.getEndpoint.getHost.dropRight(".servicebus.windows.net".length)
+  }
+
   /**
    * Identical to [[build]].
    */

--- a/core/src/main/scala/org/apache/spark/eventhubs/rdd/EventHubsRDD.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/rdd/EventHubsRDD.scala
@@ -20,10 +20,10 @@ package org.apache.spark.eventhubs.rdd
 import com.microsoft.azure.eventhubs.EventData
 import org.apache.spark.eventhubs.EventHubsConf
 import org.apache.spark.eventhubs.client.CachedEventHubsReceiver
-import org.apache.spark.eventhubs.utils.SimulatedCachedReceiver
+import org.apache.spark.eventhubs.utils.{EventHubsReceiverListener, SimulatedCachedReceiver}
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
-import org.apache.spark.{ Partition, SparkContext, TaskContext }
+import org.apache.spark.{Partition, SparkContext, TaskContext}
 
 /**
  * An [[RDD]] for consuming from Event Hubs.
@@ -38,7 +38,8 @@ import org.apache.spark.{ Partition, SparkContext, TaskContext }
  */
 private[spark] class EventHubsRDD(sc: SparkContext,
                                   val ehConf: EventHubsConf,
-                                  val offsetRanges: Array[OffsetRange])
+                                  val offsetRanges: Array[OffsetRange],
+                                  eventHubsReceiverListener: Option[EventHubsReceiverListener] = None)
     extends RDD[EventData](sc, Nil)
     with Logging
     with HasOffsetRanges {
@@ -120,7 +121,8 @@ private[spark] class EventHubsRDD(sc: SparkContext,
       cachedReceiver.receive(ehConf,
                              part.nameAndPartition,
                              part.fromSeqNo,
-                             (part.untilSeqNo - part.fromSeqNo).toInt)
+                             (part.untilSeqNo - part.fromSeqNo).toInt,
+                             eventHubsReceiverListener)
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/eventhubs/utils/EventHubsReceiverListener.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/utils/EventHubsReceiverListener.scala
@@ -1,0 +1,14 @@
+package org.apache.spark.eventhubs.utils
+
+import com.microsoft.azure.eventhubs.EventData
+import org.apache.spark.eventhubs.{NameAndPartition, SequenceNumber}
+
+trait EventHubsReceiverListener extends Serializable {
+
+  def onBatchReceiveSuccess(nAndP: NameAndPartition, elapsedTime: Long, batchSize: Int, receivedBytes: Long): Unit
+
+  def onBatchReceiveSkip(nAndP: NameAndPartition, requestSeqNo: SequenceNumber, batchSize: Int): Unit
+
+  def onReceiveFirstEvent(nAndP: NameAndPartition, firstEvent: EventData): Unit
+
+}

--- a/core/src/main/scala/org/apache/spark/eventhubs/utils/EventHubsSenderListener.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/utils/EventHubsSenderListener.scala
@@ -1,0 +1,17 @@
+package org.apache.spark.eventhubs.utils
+
+trait EventHubsSenderListener extends Serializable {
+
+  def onBatchSendSuccess(messageCount: Int, messageSizeInBytes: Int, sendElapsedTimeInNanos: Long, retryTimes: Int)
+
+  def onBatchSendFail(exception: Throwable)
+
+  def onWriterOpen(partitionId: Long, version: Long)
+
+  def onWriterClose(totalMessageCount: Int,
+                    totalMessageSizeInBytes: Int,
+                    endToEndElapsedTimeInNanos: Long,
+                    totalRetryTimes: Option[Int],
+                    totalBatches: Option[Int])
+
+}

--- a/core/src/main/scala/org/apache/spark/eventhubs/utils/SimulatedCachedReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/utils/SimulatedCachedReceiver.scala
@@ -42,7 +42,8 @@ private[spark] object SimulatedCachedReceiver extends CachedReceiver {
   override def receive(ehConf: EventHubsConf,
                        nAndP: NameAndPartition,
                        requestSeqNo: SequenceNumber,
-                       batchSize: Int): Iterator[EventData] = {
+                       batchSize: Int,
+                       eventHubsReceiverListener: Option[EventHubsReceiverListener] = None): Iterator[EventData] = {
     eventHubs(ehConf.name).receive(batchSize, nAndP.partitionId, requestSeqNo).iterator.asScala
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsForeachWriter.scala
+++ b/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsForeachWriter.scala
@@ -17,8 +17,8 @@
 
 package org.apache.spark.sql.eventhubs
 
-import com.microsoft.azure.eventhubs.{ EventData, EventHubClient }
-import org.apache.spark.eventhubs.EventHubsConf
+import com.microsoft.azure.eventhubs.{EventData, EventHubClient}
+import org.apache.spark.eventhubs.{EventHubsConf, RetryCount}
 import org.apache.spark.eventhubs.client.ClientConnectionPool
 import org.apache.spark.eventhubs.utils.RetryUtils._
 import org.apache.spark.sql.ForeachWriter
@@ -39,21 +39,38 @@ import org.apache.spark.sql.ForeachWriter
  */
 case class EventHubsForeachWriter(ehConf: EventHubsConf) extends ForeachWriter[String] {
   var client: EventHubClient = _
+  var totalMessageSizeInBytes = 0
+  var totalMessageCount = 0
+  var writerOpenTime = 0L
 
   def open(partitionId: Long, version: Long): Boolean = {
+    writerOpenTime = System.nanoTime()
     client = ClientConnectionPool.borrowClient(ehConf)
+    ehConf.senderListener().foreach(_.onWriterOpen(partitionId, version))
     true
   }
 
   def process(body: String): Unit = {
     val event = EventData.create(s"$body".getBytes("UTF-8"))
-    retryJava(client.send(event), "ForeachWriter")
+    retryJava(client.send(event), "ForeachWriter",
+      ehConf.operationRetryTimes.getOrElse(RetryCount),
+      ehConf.operationRetryExponentialDelayMs.getOrElse(10))
+    totalMessageCount += 1
+    totalMessageSizeInBytes += event.getBytes.length
   }
 
   def close(errorOrNull: Throwable): Unit = {
     errorOrNull match {
-      case t: Throwable => throw t
+      case t: Throwable =>
+        ehConf.senderListener().foreach(_.onBatchSendFail(t))
+        throw t
       case _ =>
+        ehConf.senderListener().foreach(_.onWriterClose(
+          totalMessageCount,
+          totalMessageSizeInBytes,
+          System.nanoTime() - writerOpenTime,
+          None,
+          None))
         ClientConnectionPool.returnClient(ehConf, client)
     }
   }

--- a/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsSource.scala
@@ -305,14 +305,14 @@ class EventHubsSource private[eventhubs] (sqlContext: SQLContext,
       preferredLoc = if (numExecutors > 0) {
         Some(sortedExecutors(Math.floorMod(np.hashCode, numExecutors)))
       } else None
-    } yield OffsetRange(np, fromSeqNo, untilSeqNo, preferredLoc)).filter { range =>
+    } yield OffsetRange(np, fromSeqNo, untilSeqNo, preferredLoc)).map { range =>
       if (range.untilSeqNo < range.fromSeqNo) {
         reportDataLoss(
           s"Partition ${range.nameAndPartition}'s sequence number was changed from " +
             s"${range.fromSeqNo} to ${range.untilSeqNo}, some data may have been missed")
-        false
+        OffsetRange(range.nameAndPartition, range.fromSeqNo, range.fromSeqNo, range.preferredLoc)
       } else {
-        true
+        range
       }
     }.toArray
     val rdd =

--- a/core/src/main/scala/org/apache/spark/sql/eventhubs/SerializationUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/eventhubs/SerializationUtils.scala
@@ -1,0 +1,28 @@
+package org.apache.spark.sql.eventhubs
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
+import java.util.Base64
+
+import org.apache.spark.internal.Logging
+
+object SerializationUtils extends Logging{
+
+  def serialize(obj: Any): String = {
+    val bo = new ByteArrayOutputStream
+    val so = new ObjectOutputStream(bo)
+    so.writeObject(obj)
+    so.flush()
+    val bytes = bo.toByteArray
+    logInfo(s"Serialized object size: $bytes bytes")
+    val sizeLimitInMB = 1
+    require(bytes.size < sizeLimitInMB * 1024 * 1024, s"Serialized object size is $bytes bytes, which is larger than limit $sizeLimitInMB MB")
+    Base64.getEncoder.encodeToString(bytes)
+  }
+
+  def deserialize[T](serialized: String): T = {
+    val bi = new ByteArrayInputStream(
+      Base64.getDecoder.decode(serialized))
+    val si = new ObjectInputStream(bi)
+    si.readObject.asInstanceOf[T]
+  }
+}


### PR DESCRIPTION
1. This PR is based on #474 , please merge #474 first
2. Original behavior make job failed due to partitionId matching assertion failed, so this PR don't filter out out-dated partitions, but return empty partition