### PR TITLE
Add support for different partitioning strategies to deal with reader/executor skew

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubs/package.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/package.scala
@@ -44,6 +44,7 @@ package object eventhubs {
   val DefaultPrefetchCount: Int = PartitionReceiver.DEFAULT_PREFETCH_COUNT
   val DefaultFailOnDataLoss = "true"
   val DefaultUseSimulatedClient = "false"
+  val DefaultPartitionPreferredLocationStrategy = "Hash"
   val DefaultUseExclusiveReceiver = "true"
   val StartingSequenceNumber = 0L
   val DefaultThreadPoolSize = 16
@@ -71,6 +72,11 @@ package object eventhubs {
 
   type SequenceNumber = Long
   val SequenceNumber: Long.type = Long
+
+  object PartitionPreferredLocationStrategy extends Enumeration {
+    type PartitionPreferredLocationStrategy = Value
+    val Hash,BalancedHash = Value
+  }
 
   // Allow Strings to be converted to types defined in this library.
   implicit class EventHubsString(val str: String) extends AnyVal {

--- a/core/src/test/scala/org/apache/spark/eventhubs/EventHubsConfSuite.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubs/EventHubsConfSuite.scala
@@ -269,4 +269,26 @@ class EventHubsConfSuite extends FunSuite with BeforeAndAfterAll {
     intercept[IllegalStateException] { EventHubsConf(without).validate }
   }
 
+  test("validate partitions strategy config") {
+    val eventHubConfig = testUtils.getEventHubsConf()
+
+    //check default options to make sure it defaults to hash
+    assert(eventHubConfig.partitionPreferredLocationStrategy ==
+           PartitionPreferredLocationStrategy.Hash)
+
+    //check exceptions
+    intercept[IllegalStateException] {
+      eventHubConfig
+        .set(EventHubsConf.PartitionPreferredLocationStrategyKey, "illegalconfigoption")
+        .partitionPreferredLocationStrategy
+    }
+
+    //check setting string types match expected types
+    eventHubConfig.set(EventHubsConf.PartitionPreferredLocationStrategyKey, "Hash")
+    assert(eventHubConfig.partitionPreferredLocationStrategy ==
+           PartitionPreferredLocationStrategy.Hash)
+    eventHubConfig.set(EventHubsConf.PartitionPreferredLocationStrategyKey, "BalancedHash")
+    assert(eventHubConfig.partitionPreferredLocationStrategy ==
+           PartitionPreferredLocationStrategy.BalancedHash)
+  }
 }


### PR DESCRIPTION
Adds support for alternate preferred partition location strategy.  Defaults back to original hash partition if none is set.

The default hash partitioning can create unbalanced loads for executors, with some executors having 2-3x the number of event hub readers (and AMQP connections/buffers) than others.  This can create OOM issues or lagging/partitioning issues due to the imbalance on partitions (in particular Databricks which doesn't allow fine grained control of executor size outside of VM size)). This is particularly an issue for heavy loads (e.g. near dedicated EH style loads), or cross-region reading of EH data, where it can be difficult to keep up without over provisioning the resources by 2-3x more than should be necessary.  This adds an additional option, "BalancedHash", that attempts to split the load evenly for event hubs, which can help deal with these high load situations in a more efficient manner.