### PR TITLE
add null check for properties key-value and a test case

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsWriteTask.scala
+++ b/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsWriteTask.scala
@@ -95,8 +95,13 @@ private[eventhubs] abstract class EventHubsRowWriter(inputSchema: Seq[Attribute]
       val values = unsafeMap.valueArray()
       Some(
         (0 until keys.numElements)
-          .map(i => keys.getUTF8String(i).toString -> values.getUTF8String(i).toString)
-          .toMap)
+          .map{i =>
+            if(keys.isNullAt(i))  throw new IllegalStateException("Properties cannot have a null key")
+            if(values.isNullAt(i))  throw new IllegalStateException("Properties cannot have a null value")
+            keys.getUTF8String(i).toString -> values.getUTF8String(i).toString
+          }.toMap)
+        //  .map(i => keys.getUTF8String(i).toString -> values.getUTF8String(i).toString)
+        //  .toMap)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsWriteTask.scala
+++ b/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsWriteTask.scala
@@ -100,8 +100,6 @@ private[eventhubs] abstract class EventHubsRowWriter(inputSchema: Seq[Attribute]
             if(values.isNullAt(i))  throw new IllegalStateException("Properties cannot have a null value")
             keys.getUTF8String(i).toString -> values.getUTF8String(i).toString
           }.toMap)
-        //  .map(i => keys.getUTF8String(i).toString -> values.getUTF8String(i).toString)
-        //  .toMap)
     }
   }
 


### PR DESCRIPTION
The optional Properties map attached to an event cannot have a null key or a null value. The code did not explicitly check for this and the null exception did not provide any further information. 
In this PR these checks have been added and the reason for the null exception is provided to the user.
Also, a test case has been added to check this scenario.
