### PR TITLE
Support null value in properties and throw exception for null keys in properties

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsWriteTask.scala
+++ b/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsWriteTask.scala
@@ -96,9 +96,9 @@ private[eventhubs] abstract class EventHubsRowWriter(inputSchema: Seq[Attribute]
       Some(
         (0 until keys.numElements)
           .map{i =>
-            if(keys.isNullAt(i))  throw new IllegalStateException("Properties cannot have a null key")
-            if(values.isNullAt(i))  throw new IllegalStateException("Properties cannot have a null value")
-            keys.getUTF8String(i).toString -> values.getUTF8String(i).toString
+            if(keys.isNullAt(i))  throw new NullPointerException("Properties cannot have a null key.")
+            val value = if(values.isNullAt(i)) null else values.getUTF8String(i).toString
+            keys.getUTF8String(i).toString -> value
           }.toMap)
     }
   }


### PR DESCRIPTION
This PR updates the support for null key & values in the user-defined properties bag. Specifically:
- Null values are supported in the properties bag
- Null keys are NOT supported in the properties bag. If a user sets a key to null, a NullPointerException is thrown and the user will be notified about the reason.

Also, in this PR a test case is added to check the proper behavior when a key is set to null in a property bag.

This PR assumes the underlying Java client is handling sending events with null values in the properties bag correctly, so it should not be merged to the master branch before making sure about the update in the java client.