### PR TITLE
Don't close a receiver for epoch receiver case

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubs/client/CachedEventHubsReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/client/CachedEventHubsReceiver.scala
@@ -132,7 +132,10 @@ private[client] class CachedEventHubsReceiver private (ehConf: EventHubsConf,
     val startTimeNs = System.nanoTime()
     def elapsedTimeNs = System.nanoTime() - startTimeNs
 
-    Await.result(closeReceiver(), ehConf.internalOperationTimeout)
+    if (!ehConf.useExclusiveReceiver) {
+      Await.result(closeReceiver(), ehConf.internalOperationTimeout)
+    }
+
     receiver = createReceiver(seqNo)
 
     val elapsedTimeMs = TimeUnit.NANOSECONDS.toMillis(elapsedTimeNs)


### PR DESCRIPTION
The creation of an epoch receiver will disconnect existing receivers and so there is no need to call Close() API on the existing receivers. 