### PR TITLE
Use receiver timeout for underlying API calls to Event Hubs so that connector can retry on failures

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubs/client/ClientConnectionPool.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/client/ClientConnectionPool.scala
@@ -51,7 +51,7 @@ private class ClientConnectionPool(val ehConf: EventHubsConf) extends Logging {
         s"No clients left to borrow. EventHub name: ${ehConf.name}, " +
           s"ConsumerGroup name: $consumerGroup. Creating client ${count.incrementAndGet()}")
       val connStr = ConnectionStringBuilder(ehConf.connectionString)
-      connStr.setOperationTimeout(ehConf.operationTimeout.getOrElse(DefaultOperationTimeout))
+      connStr.setOperationTimeout(ehConf.receiverTimeout.getOrElse(DefaultOperationTimeout))
       EventHubsClient.userAgent =
         s"SparkConnector-$SparkConnectorVersion-[${ehConf.name}]-[$consumerGroup]"
       while (client == null) {


### PR DESCRIPTION
Current retry logic doesn't retry on a failure because underlying API calls to the Event Hubs service uses operation timeout which is also used by the connector. So, when timeout error occurs while accessing the event hub service, there will be no remaining timeout for the connector to retry.