### PR TITLE
ConnectionString decryption fix for PySpark

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubs/EventHubsUtils.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/EventHubsUtils.scala
@@ -155,7 +155,12 @@ object EventHubsUtils extends Logging {
     val cipher = Cipher.getInstance("AES/ECB/PKCS5Padding")
 
     cipher.init(Cipher.DECRYPT_MODE, getSecretKeySpec)
-    new String(cipher.doFinal(Base64.getDecoder.decode(inputString)), StandardCharsets.UTF_8)
+    try {
+      new String(cipher.doFinal(Base64.getDecoder.decode(inputString)), StandardCharsets.UTF_8)
+    } catch {
+      case iae: IllegalArgumentException => inputString
+      case e: Exception                  => throw e
+    }
   }
 
   private def getSecretKeySpec: SecretKeySpec = {


### PR DESCRIPTION
When a user provides the connectionString in a configuration dictionary (for instance in PySpark) instead of creating an instance of EventHubsConf, the connectionString is not getting encrypted. Therefore, applying EventHubsConf.toConf results in throwing an exception. PySpark applications can't connect to Event Hubs due to this error.