### PR TITLE
Stopped serializing String property values

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsSourceProvider.scala
+++ b/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsSourceProvider.scala
@@ -188,8 +188,12 @@ private[sql] object EventHubsSourceProvider extends Serializable {
                   case d: DescribedType    => d.getDescribed
                   case default             => default
                 }
+                .mapValues {
+                  case s: String => UTF8String.fromString(s)
+                  case default   => UTF8String.fromString(Serialization.write(default))
+                }
                 .map { p =>
-                  UTF8String.fromString(p._1) -> UTF8String.fromString(Serialization.write(p._2))
+                  UTF8String.fromString(p._1) -> p._2
                 }),
             ArrayBasedMapData(
               // Don't duplicate offset, enqueued time, and seqNo

--- a/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsRelationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsRelationSuite.scala
@@ -125,7 +125,7 @@ class EventHubsRelationSuite extends QueryTest with BeforeAndAfter with SharedSQ
       ))
 
     // The expected serializes to:
-    //     [Map(E -> true, N -> "1", J -> "x-opt-partition-key", F -> 1, A -> "Hello, world.",
+    //     [Map(E -> true, N -> "1", J -> "x-opt-partition-key", F -> 1, A -> Hello, world.,
     //     M -> 13, I -> [49], G -> 1, L -> 12, B -> {}, P -> "1", C -> [52,51,50], H -> "a",
     //     K -> [0,1,2,3,0,0,0,0,0,1,2,3,0,0,0,0], O -> "987654321", D -> null)]
     val expected = properties.get
@@ -147,8 +147,9 @@ class EventHubsRelationSuite extends QueryTest with BeforeAndAfter with SharedSQ
         case d: DescribedType    => d.getDescribed
         case default             => default
       }
-      .map { p =>
-        p._1 -> Serialization.write(p._2)
+      .mapValues {
+        case s: String => s
+        case default   => Serialization.write(default)
       }
 
     val eh = newEventHub()

--- a/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsSourceSuite.scala
@@ -516,7 +516,7 @@ class EventHubsSourceSuite extends EventHubsSourceTest {
       ))
 
     // The expected serializes to:
-    //     [Map(E -> true, N -> "1", J -> "x-opt-partition-key", F -> 1, A -> "Hello, world.",
+    //     [Map(E -> true, N -> "1", J -> "x-opt-partition-key", F -> 1, A -> Hello, world.,
     //     M -> 13, I -> [49], G -> 1, L -> 12, B -> {}, P -> "1", C -> [52,51,50], H -> "a",
     //     K -> [0,1,2,3,0,0,0,0,0,1,2,3,0,0,0,0], O -> "987654321", D -> null)]
     val expected = properties.get
@@ -538,8 +538,9 @@ class EventHubsSourceSuite extends EventHubsSourceTest {
         case d: DescribedType    => d.getDescribed
         case default             => default
       }
-      .map { p =>
-        p._1 -> Serialization.write(p._2)
+      .mapValues {
+        case s: String => s
+        case default   => Serialization.write(default)
       }
 
     val eventHub = testUtils.createEventHubs(newEventHubs(), partitionCount = 1)


### PR DESCRIPTION
As noted in #511, the current implementation re-serializes strings and adds `"` around the values. For example, if your application property value is `My string value`, it becomes `"My string value"` after the values are serialized as JSON during `EventHubsSourceProvider.toInternalRow()`. Non-string values like `Deimal128` and `UnsignedLong` are **not** wrapped in quotes so this makes it extremely difficult for users of the library to effectively distinguish. If the value was actually a string representation of, for example a numeric value, then it would get wrapped while binary representations would not. Finally, if the string really is wrapped in quotes for some reason, then you get double-double quoting: `""Hello quotes!""`.