### PR TITLE
fix added quotes to string property values

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsSourceProvider.scala
+++ b/core/src/main/scala/org/apache/spark/sql/eventhubs/EventHubsSourceProvider.scala
@@ -189,7 +189,10 @@ private[sql] object EventHubsSourceProvider extends Serializable {
                   case default             => default
                 }
                 .map { p =>
-                  UTF8String.fromString(p._1) -> UTF8String.fromString(Serialization.write(p._2))
+                  p._2 match {
+                    case s: String  =>    UTF8String.fromString(p._1) -> UTF8String.fromString(s)
+                    case default    =>    UTF8String.fromString(p._1) -> UTF8String.fromString(Serialization.write(p._2))
+                  }
                 }),
             ArrayBasedMapData(
               // Don't duplicate offset, enqueued time, and seqNo
@@ -205,7 +208,10 @@ private[sql] object EventHubsSourceProvider extends Serializable {
                   case default             => default
                 }
                 .map { p =>
-                  UTF8String.fromString(p._1) -> UTF8String.fromString(Serialization.write(p._2))
+                  p._2 match {
+                    case s: String  =>    UTF8String.fromString(p._1) -> UTF8String.fromString(s)
+                    case default    =>    UTF8String.fromString(p._1) -> UTF8String.fromString(Serialization.write(p._2))
+                  }
                 })
           )
         }

--- a/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsRelationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsRelationSuite.scala
@@ -148,7 +148,10 @@ class EventHubsRelationSuite extends QueryTest with BeforeAndAfter with SharedSQ
         case default             => default
       }
       .map { p =>
-        p._1 -> Serialization.write(p._2)
+        p._2 match {
+          case s: String  =>    p._1 -> s
+          case default    =>    p._1 -> Serialization.write(p._2)
+        }
       }
 
     val eh = newEventHub()

--- a/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/eventhubs/EventHubsSourceSuite.scala
@@ -539,7 +539,10 @@ class EventHubsSourceSuite extends EventHubsSourceTest {
         case default             => default
       }
       .map { p =>
-        p._1 -> Serialization.write(p._2)
+        p._2 match {
+          case s: String  =>    p._1 -> s
+          case default    =>    p._1 -> Serialization.write(p._2)
+        }
       }
 
     val eventHub = testUtils.createEventHubs(newEventHubs(), partitionCount = 1)


### PR DESCRIPTION
This PR is to fix the issue of added quotes to the property values of type String which has been mentioned in https://github.com/Azure/azure-event-hubs-spark/issues/511. 