### PR TITLE
add receive watchdog

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubs/EventHubsConf.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/EventHubsConf.scala
@@ -159,6 +159,7 @@ final class EventHubsConf private (private val connectionStr: String)
       ConnectionStringKey,
       ConsumerGroupKey,
       ReceiverTimeoutKey,
+      MaxSilentTimeKey,
       OperationTimeoutKey,
       PrefetchCountKey,
       ThreadPoolSizeKey,
@@ -364,6 +365,27 @@ final class EventHubsConf private (private val connectionStr: String)
   }
 
   /**
+   * Set the maximum silent time for a receiver. We will try to recreate the receiver
+   * if there is no activity for the length of this duration.
+   * Default: [[DefaultMaxSilentTime]]
+   *
+   * @param d the new maximum silent time
+   * @return the updated [[EventHubsConf]] instance
+   */
+  def setMaxSilentTime(d: Duration): EventHubsConf = {
+    if (d.toMillis < MinSilentTime.toMillis) {
+      throw new IllegalArgumentException("max silent time is less than " + MinSilentTime)
+    }
+
+    set(MaxSilentTimeKey, d)
+  }
+
+  /** The current maximum silent time.  */
+  def maxSilentTime: Option[Duration] = {
+    self.get(MaxSilentTimeKey) map (str => Duration.parse(str))
+  }
+
+  /**
    * Set the operation timeout. We will retryJava failures when contacting the
    * EventHubs service for the length of this timeout.
    * Default: [[DefaultOperationTimeout]]
@@ -536,6 +558,7 @@ object EventHubsConf extends Logging {
   val MaxRatePerPartitionKey = "eventhubs.maxRatePerPartition"
   val MaxRatesPerPartitionKey = "eventhubs.maxRatesPerPartition"
   val ReceiverTimeoutKey = "eventhubs.receiverTimeout"
+  val MaxSilentTimeKey = "eventhubs.maxSilentTime"
   val OperationTimeoutKey = "eventhubs.operationTimeout"
   val PrefetchCountKey = "eventhubs.prefetchCount"
   val ThreadPoolSizeKey = "eventhubs.threadPoolSize"

--- a/core/src/main/scala/org/apache/spark/eventhubs/package.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/package.scala
@@ -19,7 +19,7 @@ package org.apache.spark
 
 import java.time.Duration
 
-import com.microsoft.azure.eventhubs.{ EventHubClient, PartitionReceiver }
+import com.microsoft.azure.eventhubs.{ EventHubClient, EventHubClientOptions, PartitionReceiver }
 import org.json4s.NoTypeHints
 import org.json4s.jackson.Serialization
 
@@ -37,6 +37,8 @@ package object eventhubs {
   val DefaultEndingPosition: EventPosition = EventPosition.fromEndOfStream
   val DefaultMaxRatePerPartition: Rate = 1000
   val DefaultReceiverTimeout: Duration = Duration.ofSeconds(60)
+  val DefaultMaxSilentTime: Duration = EventHubClientOptions.SILENT_OFF
+  val MinSilentTime: Duration = EventHubClientOptions.SILENT_MINIMUM
   val DefaultOperationTimeout: Duration = Duration.ofSeconds(300)
   val DefaultConsumerGroup: String = EventHubClient.DEFAULT_CONSUMER_GROUP_NAME
   val PrefetchCountMinimum: Int = PartitionReceiver.MINIMUM_PREFETCH_COUNT

--- a/core/src/test/scala/org/apache/spark/eventhubs/EventHubsConfSuite.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubs/EventHubsConfSuite.scala
@@ -91,6 +91,7 @@ class EventHubsConfSuite extends FunSuite with BeforeAndAfterAll {
     assert(map(MaxRatePerPartitionKey).toRate == DefaultMaxRate)
     intercept[Exception] { map(MaxRatesPerPartitionKey) }
     intercept[Exception] { map(ReceiverTimeoutKey) }
+    intercept[Exception] { map(MaxSilentTimeKey) }
     intercept[Exception] { map(OperationTimeoutKey) }
     intercept[Exception] { map(MaxEventsPerTriggerKey) }
     assert(map(UseSimulatedClientKey).toBoolean)
@@ -229,6 +230,7 @@ class EventHubsConfSuite extends FunSuite with BeforeAndAfterAll {
       .setMaxRatesPerPartition(Map(NameAndPartition("foo", 0) -> 12))
       .setMaxEventsPerTrigger(100)
       .setReceiverTimeout(Duration.ofSeconds(10))
+      .setMaxSilentTime(Duration.ofSeconds(60))
       .setOperationTimeout(Duration.ofSeconds(10))
       .setThreadPoolSize(16)
       .setPrefetchCount(100)
@@ -246,6 +248,7 @@ class EventHubsConfSuite extends FunSuite with BeforeAndAfterAll {
     originalConf("eventhubs.maxRatePerPartition")
     originalConf("eventhubs.maxRatesPerPartition")
     originalConf("eventhubs.receiverTimeout")
+    originalConf("eventhubs.maxSilentTime")
     originalConf("eventhubs.operationTimeout")
     originalConf("eventhubs.prefetchCount")
     originalConf("eventhubs.threadPoolSize")
@@ -263,6 +266,7 @@ class EventHubsConfSuite extends FunSuite with BeforeAndAfterAll {
     intercept[NoSuchElementException] { newConf("eventhubs.maxRatePerPartition") }
     intercept[NoSuchElementException] { newConf("eventhubs.maxRatesPerPartition") }
     newConf("eventhubs.receiverTimeout")
+    newConf("eventhubs.maxSilentTime")
     newConf("eventhubs.operationTimeout")
     newConf("eventhubs.prefetchCount")
     newConf("eventhubs.threadPoolSize")
@@ -322,5 +326,15 @@ class EventHubsConfSuite extends FunSuite with BeforeAndAfterAll {
 
     eventHubConfig.setOperationTimeout(Duration.ofMinutes(3))
     assert(eventHubConfig.operationTimeout.get.toMinutes == 3)
+  }
+
+  test("validate - max silent time") {
+    val eventHubConfig = testUtils.getEventHubsConf()
+    intercept[IllegalArgumentException] {
+      eventHubConfig.setMaxSilentTime(Duration.ofSeconds(29))
+    }
+
+    eventHubConfig.setMaxSilentTime(Duration.ofMinutes(1))
+    assert(eventHubConfig.maxSilentTime.get.toMinutes == 1)
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-eventhubs</artifactId>
-            <version>3.0.2</version>
+            <version>3.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
Add a watchdog to the receive so that receivers can be recreated if there is no traffic for a user-specified period.