### PR TITLE
Fix typo in docs when importing datetime library

### DIFF
--- a/docs/PySpark/structured-streaming-pyspark.md
+++ b/docs/PySpark/structured-streaming-pyspark.md
@@ -99,6 +99,7 @@ The position can be an enqueued time, offset, sequence number, the start of the 
 
 ```python
 from datetime import datetime as dt
+import json
 
 # Start from beginning of stream
 startOffset = "-1"

--- a/docs/PySpark/structured-streaming-pyspark.md
+++ b/docs/PySpark/structured-streaming-pyspark.md
@@ -98,7 +98,7 @@ The position can be an enqueued time, offset, sequence number, the start of the 
 
 
 ```python
-import datetime from datetime as dt
+from datetime import datetime as dt
 
 # Start from beginning of stream
 startOffset = "-1"


### PR DESCRIPTION
Hi there,

I changed a line in the pyspark documentation.
The existing line `import datetime from datetime as dt` returns `SyntaxError: invalid syntax`.
The correct importing statement is instead: `from datetime import datetime as dt`.
