### PR TITLE
Service principal aad auth - params added to service principal callback

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubs/EventHubsConf.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/EventHubsConf.scala
@@ -617,7 +617,7 @@ final class EventHubsConf private (private val connectionStr: String)
   def setAadAuthCallback(callback: AadAuthenticationCallback): EventHubsConf = {
     setUseAadAuth(true)
     set(AadAuthCallbackKey, callback.getClass.getName)
-    set(AadAuthCallbackParams, callback.args.mkString(","))
+    set(AadAuthCallbackParams, callback.params.mkString(","))
   }
 
   def aadAuthCallback(): Option[AadAuthenticationCallback] = {

--- a/core/src/main/scala/org/apache/spark/eventhubs/utils/AadAuthenticationCallback.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/utils/AadAuthenticationCallback.scala
@@ -2,6 +2,6 @@ package org.apache.spark.eventhubs.utils
 
 import com.microsoft.azure.eventhubs.AzureActiveDirectoryTokenProvider.AuthenticationCallback
 
-abstract class AadAuthenticationCallback(val args: String*) extends AuthenticationCallback with Serializable {
+abstract class AadAuthenticationCallback(val params: String*) extends AuthenticationCallback with Serializable {
   def authority: String
 }

--- a/core/src/main/scala/org/apache/spark/eventhubs/utils/AadAuthenticationCallback.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/utils/AadAuthenticationCallback.scala
@@ -2,6 +2,6 @@ package org.apache.spark.eventhubs.utils
 
 import com.microsoft.azure.eventhubs.AzureActiveDirectoryTokenProvider.AuthenticationCallback
 
-abstract class AadAuthenticationCallback(val params: String*) extends AuthenticationCallback with Serializable {
+abstract class AadAuthenticationCallback(val params: Seq[String]) extends AuthenticationCallback with Serializable {
   def authority: String
 }

--- a/core/src/main/scala/org/apache/spark/eventhubs/utils/AadAuthenticationCallback.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/utils/AadAuthenticationCallback.scala
@@ -2,6 +2,6 @@ package org.apache.spark.eventhubs.utils
 
 import com.microsoft.azure.eventhubs.AzureActiveDirectoryTokenProvider.AuthenticationCallback
 
-trait AadAuthenticationCallback extends AuthenticationCallback with Serializable {
+abstract class AadAuthenticationCallback(val args: String*) extends AuthenticationCallback with Serializable {
   def authority: String
 }

--- a/core/src/test/scala/org/apache/spark/eventhubs/EventHubsConfSuite.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubs/EventHubsConfSuite.scala
@@ -118,7 +118,8 @@ class EventHubsConfSuite extends FunSuite with BeforeAndAfterAll {
         }),
         MaxEventsPerTriggerKey -> 4.toString,
         UseAadAuthKey -> "true",
-        AadAuthCallbackKey -> classOf[AadAuthenticationCallbackMock].getName
+        AadAuthCallbackKey -> classOf[AadAuthenticationCallbackMock].getName,
+        AadAuthCallbackParams -> ""
       ))
 
     val expectedConf = EventHubsConf(expectedConnStr)

--- a/core/src/test/scala/org/apache/spark/eventhubs/EventHubsConfSuite.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubs/EventHubsConfSuite.scala
@@ -119,7 +119,7 @@ class EventHubsConfSuite extends FunSuite with BeforeAndAfterAll {
         MaxEventsPerTriggerKey -> 4.toString,
         UseAadAuthKey -> "true",
         AadAuthCallbackKey -> classOf[AadAuthenticationCallbackMock].getName,
-        AadAuthCallbackParams -> ""
+        AadAuthCallbackParams -> "param1,param2"
       ))
 
     val expectedConf = EventHubsConf(expectedConnStr)
@@ -127,7 +127,7 @@ class EventHubsConfSuite extends FunSuite with BeforeAndAfterAll {
       .setStartingPosition(expectedPosition)
       .setStartingPositions(expectedPositions)
       .setMaxEventsPerTrigger(4L)
-      .setAadAuthCallback(new AadAuthenticationCallbackMock())
+      .setAadAuthCallback(new AadAuthenticationCallbackMock("param1", "param2"))
 
     assert(expectedConf.equals(actualConf))
   }

--- a/core/src/test/scala/org/apache/spark/eventhubs/utils/AadAuthenticationCallbackMock.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubs/utils/AadAuthenticationCallbackMock.scala
@@ -1,7 +1,7 @@
 package org.apache.spark.eventhubs.utils
 import java.util.concurrent.CompletableFuture
 
-class AadAuthenticationCallbackMock(params: String*) extends AadAuthenticationCallback(params: _*) {
+class AadAuthenticationCallbackMock(params: String*) extends AadAuthenticationCallback(params) {
   override def acquireToken(s: String, s1: String, o: Any): CompletableFuture[String] = {
     new CompletableFuture[String]()
   }

--- a/core/src/test/scala/org/apache/spark/eventhubs/utils/AadAuthenticationCallbackMock.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubs/utils/AadAuthenticationCallbackMock.scala
@@ -1,7 +1,7 @@
 package org.apache.spark.eventhubs.utils
 import java.util.concurrent.CompletableFuture
 
-class AadAuthenticationCallbackMock extends AadAuthenticationCallback {
+class AadAuthenticationCallbackMock(params: String*) extends AadAuthenticationCallback(params: _*) {
   override def acquireToken(s: String, s1: String, o: Any): CompletableFuture[String] = {
     new CompletableFuture[String]()
   }

--- a/docs/use-aad-authentication-to-connect-eventhubs.md
+++ b/docs/use-aad-authentication-to-connect-eventhubs.md
@@ -15,15 +15,15 @@ import java.util.concurrent.CompletableFuture
 import com.microsoft.aad.msal4j.{IAuthenticationResult, _}
 import org.apache.spark.eventhubs.utils.AadAuthenticationCallback
 
-case class AuthBySecretCallBack() extends AadAuthenticationCallback{
+class AuthBySecretCallBack(params: String*) extends AadAuthenticationCallback(params) {
 
   implicit def toJavaFunction[A, B](f: Function1[A, B]) = new java.util.function.Function[A, B] {
     override def apply(a: A): B = f(a)
   }
-  override def authority: String = "your-tenant-id"
+  override def authority: String = "your-tenant-id" //or taken from "params"
 
-  val clientId: String = "your-client-id"
-  val clientSecret: String = "your-client-secret"
+  val clientId: String = "your-client-id" //or taken from "params"
+  val clientSecret: String = "your-client-secret" //or taken from "params"
 
   override def acquireToken(audience: String, authority: String, state: Any): CompletableFuture[String] = try {
     var app = ConfidentialClientApplication
@@ -49,7 +49,7 @@ val connectionString = ConnectionStringBuilder()
   .build
 val ehConf = EventHubsConf(connectionString)
   .setConsumerGroup("consumerGroup")
-  .setAadAuthCallback(AuthBySecretCallBack())
+  .setAadAuthCallback(new AuthBySecretCallBack(/* optional "params" can be passed here */))
 ```
 
 
@@ -65,15 +65,15 @@ import java.util.concurrent.CompletableFuture
 import com.microsoft.aad.msal4j.{ClientCredentialFactory, ClientCredentialParameters, ConfidentialClientApplication, IAuthenticationResult}
 import org.apache.commons.io.FileUtils
 import org.apache.spark.eventhubs.utils.AadAuthenticationCallback
-case class AuthByCertCallBack() extends AadAuthenticationCallback {
+class AuthByCertCallBack(params: String*) extends AadAuthenticationCallback(params) {
   implicit def toJavaFunction[A, B](f: Function1[A, B]) = new java.util.function.Function[A, B] {
     override def apply(a: A): B = f(a)
   }
-  val clientId: String = "your-client-id"
-  val cert: Array[Byte] = FileUtils.readFileToByteArray(new File("your-cert-local-path"))
-  val certPassword: String = "password-of-your-cert"
+  val clientId: String = "your-client-id" //or taken from "params"
+  val cert: Array[Byte] = FileUtils.readFileToByteArray(new File("your-cert-local-path")) //or taken from "params"
+  val certPassword: String = "password-of-your-cert" //or taken from "params"
 
-  override def authority: String = "your-tenant-id"
+  override def authority: String = "your-tenant-id" //or taken from "params"
   override def acquireToken(audience: String,
                             authority: String,
                             state: Any): CompletableFuture[String] =
@@ -103,5 +103,5 @@ val connectionString = ConnectionStringBuilder()
   .build
 val ehConf = EventHubsConf(connectionString)
   .setConsumerGroup("consumerGroup")
-  .setAadAuthCallback(AuthByCertCallBack())
+  .setAadAuthCallback(new AuthByCertCallBack(/* optional "params" can be passed here */))
 ```


### PR DESCRIPTION
Problem I had here is that service principal callback couldn't have any parameters passed to it:
```scala
case class AuthBySecretCallBack() extends AadAuthenticationCallback {

  implicit def toJavaFunction[A, B](f: Function1[A, B]) = new java.util.function.Function[A, B] {
    override def apply(a: A): B = f(a)
  }
  override def authority: String = "your-tenant-id"

  val clientId: String = "your-client-id"
  val clientSecret: String = "your-client-secret"

//...
}
```
In the above code authority, clientId, clientSecret are hard coded values which is unacceptable in my case. I tried to do sth like:
```scala
  override def authority: String = dbutils.secrets.get(SecretScopeName, TenantID)
  val clientId: String = dbutils.secrets.get(SecretScopeName, ClientId)
  val clientSecret: String = dbutils.secrets.get(SecretScopeName, ClientSecret)
```
but then I got an error. So in this pull request I changed the way of defining this service principal auth callback and I added parameters to it, now it looks like this:
```scala
class AuthBySecretCallBack(params: String*) extends AadAuthenticationCallback(params) {

  implicit def toJavaFunction[A, B](f: Function1[A, B]) = new java.util.function.Function[A, B] {
    override def apply(a: A): B = f(a)
  }
  override def authority: String = "your-tenant-id" //or taken from "params"

  val clientId: String = "your-client-id" //or taken from "params"
  val clientSecret: String = "your-client-secret" //or taken from "params"

  override def acquireToken(audience: String, authority: String, state: Any): CompletableFuture[String] = try {
    var app = ConfidentialClientApplication
      .builder("clientId", ClientCredentialFactory.createFromSecret(this.clientSecret))
      .authority("https://login.microsoftonline.com/" + authority)
      .build

    val parameters = ClientCredentialParameters.builder(Collections.singleton(audience + ".default")).build

    app.acquireToken(parameters).thenApply((result: IAuthenticationResult) => result.accessToken())
  } catch {
    case e: Exception =>
      val failed = new CompletableFuture[String]
      failed.completeExceptionally(e)
      failed
  }
}
```
Thanks to "params" argument I can now pass parameters to callback and run my spark job without any issues.