### PR TITLE
recreate the client if ReactorDispatcher is closed

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubs/client/CachedEventHubsReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/client/CachedEventHubsReceiver.scala
@@ -391,11 +391,11 @@ private[spark] object CachedEventHubsReceiver extends CachedReceiver with Loggin
     } catch {
       case completionExecution: CompletionException =>
         val exceptionCause = completionExecution.getCause
-        if (exceptionCause != null &&  exceptionCause.isInstanceOf[RejectedExecutionException] && exceptionCause.getMessage.contains("ReactorDispatcher")) {
+        if (exceptionCause != null &&  exceptionCause.isInstanceOf[RejectedExecutionException] && exceptionCause.getMessage.contains("ReactorDispatcher instance is closed")) {
           // reactor dispatcher closed case
           logInfo(s"(TID $taskId) EventHubsCachedReceiver receive execution for namespaceUri ${ehConf.namespaceUri} " +
             s"EventHubNameAndPartition $nAndP consumer group ${ehConf.consumerGroup.getOrElse(DefaultConsumerGroup)} " +
-            s"failed with $completionExecution. Try to recerate the entire CachedEventHubsReceiver instance in order to " +
+            s"failed with $completionExecution. Try to recreate the entire CachedEventHubsReceiver instance in order to " +
             s"use a fresh EventHubClient from the underlying java SDK, then try receiving events again.")
           receiver.client.close();
           receiver = CachedEventHubsReceiver(ehConf, nAndP, requestSeqNo)
@@ -406,8 +406,8 @@ private[spark] object CachedEventHubsReceiver extends CachedReceiver with Loggin
         } else if (exceptionCause != null &&  exceptionCause.isInstanceOf[ReceiverDisconnectedException]) {
           logInfo(s"(TID $taskId) EventHubsCachedReceiver receive execution for namespaceUri ${ehConf.namespaceUri} " +
             s"EventHubNameAndPartition $nAndP consumer group ${ehConf.consumerGroup.getOrElse(DefaultConsumerGroup)} " +
-            s"failed becuase another receiver for the same <NS-EH-CG-Part> combo has been created and cause this one " +
-            s"to get discnnected. The full error is: $completionExecution. Throw the exception so that the driver can " +
+            s"failed because another receiver for the same <NS-EH-CG-Part> combo has been created and caused this one " +
+            s"to get disconnected. The full error is: $completionExecution. Throw the exception so that the driver can " +
             s"retry the task.")
           throw completionExecution
         } else {

--- a/core/src/main/scala/org/apache/spark/eventhubs/client/CachedEventHubsReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/client/CachedEventHubsReceiver.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.eventhubs.client
 
 import java.time.Duration
-import java.util.concurrent.TimeUnit
+import java.util.concurrent._
 
 import com.microsoft.azure.eventhubs._
 import org.apache.spark.SparkEnv
@@ -386,7 +386,35 @@ private[spark] object CachedEventHubsReceiver extends CachedReceiver with Loggin
         CachedEventHubsReceiver(ehConf, nAndP, requestSeqNo)
       })
     }
-    receiver.receive(requestSeqNo, batchSize)
+    try {
+      receiver.receive(requestSeqNo, batchSize)
+    } catch {
+      case completionExecution: CompletionException =>
+        val exceptionCause = completionExecution.getCause
+        if (exceptionCause != null &&  exceptionCause.isInstanceOf[RejectedExecutionException] && exceptionCause.getMessage.contains("ReactorDispatcher")) {
+          // reactor dispatcher closed case
+          logInfo(s"(TID $taskId) EventHubsCachedReceiver receive execution for namespaceUri ${ehConf.namespaceUri} " +
+            s"EventHubNameAndPartition $nAndP consumer group ${ehConf.consumerGroup.getOrElse(DefaultConsumerGroup)} " +
+            s"failed with $completionExecution. Try to recerate the entire CachedEventHubsReceiver instance in order to " +
+            s"use a fresh EventHubClient from the underlying java SDK, then try receiving events again.")
+          receiver.client.close();
+          receiver = CachedEventHubsReceiver(ehConf, nAndP, requestSeqNo)
+          receivers.synchronized {
+            receivers.update(key(ehConf, nAndP), receiver)
+          }
+          receiver.receive(requestSeqNo, batchSize)
+        } else if (exceptionCause != null &&  exceptionCause.isInstanceOf[ReceiverDisconnectedException]) {
+          logInfo(s"(TID $taskId) EventHubsCachedReceiver receive execution for namespaceUri ${ehConf.namespaceUri} " +
+            s"EventHubNameAndPartition $nAndP consumer group ${ehConf.consumerGroup.getOrElse(DefaultConsumerGroup)} " +
+            s"failed becuase another receiver for the same <NS-EH-CG-Part> combo has been created and cause this one " +
+            s"to get discnnected. The full error is: $completionExecution. Throw the exception so that the driver can " +
+            s"retry the task.")
+          throw completionExecution
+        } else {
+          throw completionExecution
+        }
+
+    }
   }
 
   def apply(ehConf: EventHubsConf,


### PR DESCRIPTION
Spark Task Preemption could result in closing the ReactorDispatcher object in the client object if it happens during a blocking IO operation on a receiver/sender channel. This makes the client unusable and any upcoming task using that client gets java.util.concurrent.RejectedExecutionException with "ReactorDispatcher instance is closed" message and fails the entire job. (issue #612)
This PR adds exception handling in the receive method in the CachedEventHubsReceiver object to take care of this situation. In this case, the client should be recreated and the new client should be used to create an EventHubsReceiver and update the cache.